### PR TITLE
feat: implemented re-approval flow for mentors flagged as reapproval_…

### DIFF
--- a/src/Services/ReApprovalEmail.jsx
+++ b/src/Services/ReApprovalEmail.jsx
@@ -1,0 +1,32 @@
+import emailjs from "emailjs-com";
+
+const SERVICE_ID = "service_pj38ic4";
+const REAPPROVAL_TEMPLATE_ID = "template_km87him";
+const PUBLIC_KEY = "I0V8D80ZeFRR4AnJ0";
+
+const ReApprovalEmail = async (toEmail, toName, fieldsArray, reason, updateLink) => {
+  const toFieldsHTML = fieldsArray.map((field) => `${field}`).join(", ");
+  const templateParams = {
+    to_name: toName,
+    to_reason: reason,
+    to_email: toEmail,
+    to_fields: toFieldsHTML,
+    update_link: updateLink,
+  };
+
+  try {
+    const response = await emailjs.send(
+      SERVICE_ID,
+      REAPPROVAL_TEMPLATE_ID,
+      templateParams,
+      PUBLIC_KEY
+    );
+    console.log("Re-Approval Email Sent to:", toEmail, response);
+    return response; // Return response for success confirmation
+  } catch (error) {
+    console.error("Error sending re-approval email:", error.text || error);
+    throw new Error(`Failed to send re-approval email: ${error.text || error.message}`);
+  }
+};
+
+export default ReApprovalEmail;

--- a/src/Services/RejectedEmail.jsx
+++ b/src/Services/RejectedEmail.jsx
@@ -1,27 +1,27 @@
-import emailjs from "emailjs-com";
+// import emailjs from "emailjs-com";
 
-const SERVICE_ID = "service_pj38ic4";
-const REJECTION_TEMPLATE_ID = "template_km87him";
-const PUBLIC_KEY = "I0V8D80ZeFRR4AnJ0";
+// const SERVICE_ID = "service_pj38ic4";
+// const REJECTION_TEMPLATE_ID = "template_km87him";
+// const PUBLIC_KEY = "I0V8D80ZeFRR4AnJ0";
 
-const RejectedEmail = async (toEmail, toName, toReason) => {
-  try {
-    const templateParams = {
-      to_name: toName,
-      to_email: toEmail,
-      to_reason: toReason,
-    };
+// const RejectedEmail = async (toEmail, toName, toReason) => {
+//   try {
+//     const templateParams = {
+//       to_name: toName,
+//       to_email: toEmail,
+//       to_reason: toReason,
+//     };
 
-    await emailjs.send(
-      SERVICE_ID,
-      REJECTION_TEMPLATE_ID,
-      templateParams,
-      PUBLIC_KEY
-    );
-    console.log("Rejection Email Sent to:", toEmail);
-  } catch (error) {
-    console.error("Error sending rejection email:", error.text || error);
-  }
-};
+//     await emailjs.send(
+//       SERVICE_ID,
+//       REJECTION_TEMPLATE_ID,
+//       templateParams,
+//       PUBLIC_KEY
+//     );
+//     console.log("Rejection Email Sent to:", toEmail);
+//   } catch (error) {
+//     console.error("Error sending rejection email:", error.text || error);
+//   }
+// };
 
-export default RejectedEmail;
+// export default RejectedEmail;

--- a/src/admin/AdminDashboard.jsx
+++ b/src/admin/AdminDashboard.jsx
@@ -4,7 +4,7 @@ import Footer from "../components/layout/Footer";
 import React, { useEffect, useState } from "react";
 import { db } from "../BACKEND/firebase";
 import ApprovedEmail from "../Services/ApprovedEmail";
-import RejectedEmail from "../Services/RejectedEmail";
+// import RejectedEmail from "../Services/RejectedEmail";
 import {
   collection,
   getDocs,
@@ -91,11 +91,11 @@ function AdminDashboardUI() {
       return;
     }
     try {
-      await RejectedEmail(
-        selectedMentor.email,
-        selectedMentor.name,
-        rejectReason
-      );
+      // await RejectedEmail(
+      //   selectedMentor.email,
+      //   selectedMentor.name,
+      //   rejectReason
+      // );
       await deleteDoc(doc(db, "mentorRequest", selectedMentor.userId));
       await updateDoc(doc(db, "users", selectedMentor.userId), {
         userType: "student",
@@ -151,53 +151,100 @@ function AdminDashboardUI() {
       <Navbar />
       <section className="pt-24 pb-12 min-h-screen bg-gradient-to-br from-gray-800 via-gray-900 to-blue-900">
         <div className="container lg:mt-10 mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="max-w-7xl mx-auto bg-gray-800/80 backdrop-blur-md p-6 sm:p-8 rounded-2xl shadow-xl">
-            <h2 className="text-3xl sm:text-4xl font-bold text-center text-white mb-8">
+          <div className="max-w-7xl mx-auto bg-gray-800/80 backdrop-blur-md p-6 sm:p-8 rounded-2xl shadow-xl border border-gray-700/30">
+            <h2 className="text-3xl sm:text-4xl font-bold text-center text-white mb-8 tracking-tight">
               Admin Dashboard
             </h2>
 
             {/* Tabs */}
             <div className="flex flex-wrap gap-2 sm:gap-4 border-b border-gray-700 mb-8 overflow-x-auto scrollbar-hide">
               <button
-                className={`py-3 px-4 sm:px-6 font-medium text-sm sm:text-base transition-colors duration-300 ${
+                className={`relative py-3 px-4 sm:px-6 font-medium text-sm sm:text-base transition-colors duration-300 group ${
                   activeTab === "requests"
-                    ? "text-yellow-400 border-b-2 border-yellow-400"
+                    ? "text-yellow-400 border-b-4 border-yellow-400"
                     : "text-gray-400 hover:text-yellow-300"
                 }`}
                 onClick={() => setActiveTab("requests")}
               >
                 Pending Requests ({requests.length})
+                <span
+                  className={`absolute bottom-0 left-0 w-full h-1 bg-yellow-400/30 transform transition-transform duration-300 ${
+                    activeTab === "requests"
+                      ? "scale-x-100"
+                      : "scale-x-0 group-hover:scale-x-100"
+                  }`}
+                ></span>
               </button>
               <button
-                className={`py-3 px-4 sm:px-6 font-medium text-sm sm:text-base transition-colors duration-300 ${
+                className={`relative py-3 px-4 sm:px-6 font-medium text-sm sm:text-base transition-colors duration-300 group ${
                   activeTab === "mentors"
-                    ? "text-yellow-400 border-b-2 border-yellow-400"
+                    ? "text-yellow-400 border-b-4 border-yellow-400"
                     : "text-gray-400 hover:text-yellow-300"
                 }`}
                 onClick={() => setActiveTab("mentors")}
               >
                 Approved Mentors ({approvedMentors.length})
+                <span
+                  className={`absolute bottom-0 left-0 w-full h-1 bg-yellow-400/30 transform transition-transform duration-300 ${
+                    activeTab === "mentors"
+                      ? "scale-x-100"
+                      : "scale-x-0 group-hover:scale-x-100"
+                  }`}
+                ></span>
               </button>
               <button
-                className={`py-3 px-4 sm:px-6 font-medium text-sm sm:text-base transition-colors duration-300 ${
+                className={`relative py-3 px-4 sm:px-6 font-medium text-sm sm:text-base transition-colors duration-300 group ${
                   activeTab === "users"
-                    ? "text-yellow-400 border-b-2 border-yellow-400"
+                    ? "text-yellow-400 border-b-4 border-yellow-400"
                     : "text-gray-400 hover:text-yellow-300"
                 }`}
                 onClick={() => setActiveTab("users")}
               >
                 All Users ({allUsers.length})
+                <span
+                  className={`absolute bottom-0 left-0 w-full h-1 bg-yellow-400/30 transform transition-transform duration-300 ${
+                    activeTab === "users"
+                      ? "scale-x-100"
+                      : "scale-x-0 group-hover:scale-x-100"
+                  }`}
+                ></span>
               </button>
             </div>
 
             {/* Pending Requests Tab */}
             {activeTab === "requests" && (
               <div className="space-y-6">
-                <h3 className="text-xl sm:text-2xl font-semibold text-yellow-400 mb-4">
+                <h3 className="text-xl sm:text-2xl font-semibold text-yellow-400 mb-4 flex items-center">
+                  <svg
+                    className="w-6 h-6 mr-2 text-yellow-400"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"
+                    />
+                  </svg>
                   Pending Mentor Requests
                 </h3>
                 {requests.length === 0 ? (
-                  <div className="text-center py-12 bg-gray-700/50 rounded-lg">
+                  <div className="text-center py-12 bg-gray-700/50 rounded-lg border border-gray-600/20">
+                    <svg
+                      className="w-12 h-12 mx-auto mb-3 text-gray-500"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={1.5}
+                        d="M9 13h6m-3-3v6m-9 1V7a2 2 0 012-2h6l2 2h6a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2z"
+                      />
+                    </svg>
                     <p className="text-gray-400 text-lg">No pending requests</p>
                   </div>
                 ) : (
@@ -205,14 +252,33 @@ function AdminDashboardUI() {
                     {requests.map((request) => (
                       <div
                         key={request.id}
-                        className="bg-gray-700/50 backdrop-blur-sm p-6 rounded-lg shadow-md hover:shadow-lg transition-all duration-300 transform hover:-translate-y-1"
+                        className="bg-gray-700/50 backdrop-blur-sm p-6 rounded-xl shadow-lg border border-gray-600/20 transition-all duration-300 hover:border-yellow-400/50 hover:shadow-xl transform hover:-translate-y-1"
                       >
                         <div className="flex flex-col h-full">
                           <div className="flex-grow">
-                            <h4 className="text-lg sm:text-xl font-semibold text-white mb-2">
+                            <h4 className="text-lg sm:text-xl font-semibold text-white mb-2 flex items-center">
+                              <svg
+                                className="w-5 h-5 mr-2 text-yellow-400"
+                                fill="currentColor"
+                                viewBox="0 0 20 20"
+                              >
+                                <path
+                                  fillRule="evenodd"
+                                  d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z"
+                                  clipRule="evenodd"
+                                />
+                              </svg>
                               {request.name}
                             </h4>
-                            <p className="text-yellow-400 text-sm sm:text-base mb-3">
+                            <p className="text-yellow-400 text-sm sm:text-base mb-3 flex items-center">
+                              <svg
+                                className="w-4 h-4 mr-2 text-yellow-400"
+                                fill="currentColor"
+                                viewBox="0 0 20 20"
+                              >
+                                <path d="M2.003 5.884L10 9.882l7.997-3.998A2 2 0 0016 4H4a2 2 0 00-1.997 1.884z" />
+                                <path d="M18 8.118l-8 4-8-4V14a2 2 0 002 2h12a2 2 0 002-2V8.118z" />
+                              </svg>
                               {request.email}
                             </p>
                             <div className="mb-3">
@@ -235,19 +301,19 @@ function AdminDashboardUI() {
                           <div className="flex flex-wrap gap-2 mt-4">
                             <Link
                               to={`/viewMentorDetails/${request.id}`}
-                              className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded text-sm font-medium transition-colors duration-200 flex-grow text-center"
+                              className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-200 flex-grow text-center shadow-md hover:shadow-blue-600/30"
                             >
                               View Details
                             </Link>
                             <button
                               onClick={() => handleApprove(request)}
-                              className="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded text-sm font-medium transition-colors duration-200 flex-grow"
+                              className="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-200 flex-grow shadow-md hover:shadow-green-600/30"
                             >
                               Approve
                             </button>
                             <button
                               onClick={() => handleReject(request)}
-                              className="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded text-sm font-medium transition-colors duration-200 flex-grow"
+                              className="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-200 flex-grow shadow-md hover:shadow-red-600/30"
                             >
                               Reject
                             </button>
@@ -263,28 +329,54 @@ function AdminDashboardUI() {
             {/* Approved Mentors Tab */}
             {activeTab === "mentors" && (
               <div className="space-y-6">
-                <h3 className="text-xl sm:text-2xl font-semibold text-yellow-400 mb-4">
+                <h3 className="text-xl sm:text-2xl font-semibold text-yellow-400 mb-4 flex items-center">
+                  <svg
+                    className="w-6 h-6 mr-2 text-yellow-400"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z"
+                    />
+                  </svg>
                   Approved Mentors
                 </h3>
                 {approvedMentors.length === 0 ? (
-                  <div className="text-center py-12 bg-gray-700/50 rounded-lg">
+                  <div className="text-center py-12 bg-gray-700/50 rounded-lg border border-gray-600/20">
+                    <svg
+                      className="w-12 h-12 mx-auto mb-3 text-gray-500"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={1.5}
+                        d="M9 13h6m-3-3v6m-9 1V7a2 2 0 012-2h6l2 2h6a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2z"
+                      />
+                    </svg>
                     <p className="text-gray-400 text-lg">No approved mentors</p>
                   </div>
                 ) : (
-                  <div className="overflow-x-auto rounded-lg">
-                    <table className="min-w-full bg-gray-700/50 backdrop-blur-sm rounded-lg">
-                      <thead className="bg-gray-600/50">
+                  <div className="overflow-x-auto rounded-xl shadow-lg border border-gray-600/20">
+                    <table className="min-w-full bg-gray-700/70 backdrop-blur-sm rounded-xl">
+                      <thead className="bg-gray-600/70">
                         <tr>
-                          <th className="px-4 sm:px-6 py-3 text-left text-xs sm:text-sm font-medium text-gray-200 uppercase tracking-wider">
+                          <th className="px-4 sm:px-6 py-4 text-left text-xs sm:text-sm font-medium text-gray-200 uppercase tracking-wider">
                             Name
                           </th>
-                          <th className="px-4 sm:px-6 py-3 text-left text-xs sm:text-sm font-medium text-gray-200 uppercase tracking-wider">
+                          <th className="px-4 sm:px-6 py-4 text-left text-xs sm:text-sm font-medium text-gray-200 uppercase tracking-wider">
                             Email
                           </th>
-                          <th className="px-4 sm:px-6 py-3 text-left text-xs sm:text-sm font-medium text-gray-200 uppercase tracking-wider">
+                          <th className="px-4 sm:px-6 py-4 text-left text-xs sm:text-sm font-medium text-gray-200 uppercase tracking-wider">
                             Expertise
                           </th>
-                          <th className="px-4 sm:px-6 py-3 text-left text-xs sm:text-sm font-medium text-gray-200 uppercase tracking-wider">
+                          <th className="px-4 sm:px-6 py-4 text-left text-xs sm:text-sm font-medium text-gray-200 uppercase tracking-wider">
                             Actions
                           </th>
                         </tr>
@@ -293,9 +385,9 @@ function AdminDashboardUI() {
                         {approvedMentors.map((mentor) => (
                           <tr
                             key={mentor.id}
-                            className="hover:bg-gray-600/30 transition-colors duration-200"
+                            className="hover:bg-gray-600/40 transition-colors duration-200"
                           >
-                            <td className="px-4 sm:px-6 py-4 text-sm sm:text-base text-white">
+                            <td className="px-4 sm:px-6 py-4 text-sm sm:text-base text-white font-medium">
                               {mentor.name}
                             </td>
                             <td className="px-4 sm:px-6 py-4 text-sm sm:text-base text-gray-300">
@@ -305,11 +397,11 @@ function AdminDashboardUI() {
                               {mentor.expertise}
                             </td>
                             <td className="px-4 sm:px-6 py-4 text-sm sm:text-base">
-                              <div className="flex space-x-2">
-                                <button className="bg-yellow-500 hover:bg-yellow-600 text-gray-900 px-3 sm:px-4 py-1 sm:py-2 rounded text-xs sm:text-sm font-medium transition-colors duration-200">
+                              <div className="flex space-x-3">
+                                <button className="bg-yellow-500 hover:bg-yellow-600 text-gray-900 px-3 sm:px-4 py-1 sm:py-2 rounded-lg text-xs sm:text-sm font-medium transition-colors duration-200 shadow-md hover:shadow-yellow-500/30">
                                   Edit
                                 </button>
-                                <button className="bg-red-600 hover:bg-red-700 text-white px-3 sm:px-4 py-1 sm:py-2 rounded text-xs sm:text-sm font-medium transition-colors duration-200">
+                                <button className="bg-red-600 hover:bg-red-700 text-white px-3 sm:px-4 py-1 sm:py-2 rounded-lg text-xs sm:text-sm font-medium transition-colors duration-200 shadow-md hover:shadow-red-600/30">
                                   Delete
                                 </button>
                               </div>
@@ -326,28 +418,54 @@ function AdminDashboardUI() {
             {/* All Users Tab */}
             {activeTab === "users" && (
               <div className="space-y-6">
-                <h3 className="text-xl sm:text-2xl font-semibold text-yellow-400 mb-4">
+                <h3 className="text-xl sm:text-2xl font-semibold text-yellow-400 mb-4 flex items-center">
+                  <svg
+                    className="w-6 h-6 mr-2 text-yellow-400"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
+                    />
+                  </svg>
                   All Users
                 </h3>
                 {allUsers.length === 0 ? (
-                  <div className="text-center py-12 bg-gray-700/50 rounded-lg">
+                  <div className="text-center py-12 bg-gray-700/50 rounded-lg border border-gray-600/20">
+                    <svg
+                      className="w-12 h-12 mx-auto mb-3 text-gray-500"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={1.5}
+                        d="M9 13h6m-3-3v6m-9 1V7a2 2 0 012-2h6l2 2h6a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2z"
+                      />
+                    </svg>
                     <p className="text-gray-400 text-lg">No users found</p>
                   </div>
                 ) : (
-                  <div className="overflow-x-auto rounded-lg">
-                    <table className="min-w-full bg-gray-700/50 backdrop-blur-sm rounded-lg">
-                      <thead className="bg-gray-600/50">
+                  <div className="overflow-x-auto rounded-xl shadow-lg border border-gray-600/20">
+                    <table className="min-w-full bg-gray-700/70 backdrop-blur-sm rounded-xl">
+                      <thead className="bg-gray-600/70">
                         <tr>
-                          <th className="px-4 sm:px-6 py-3 text-left text-xs sm:text-sm font-medium text-gray-200 uppercase tracking-wider">
+                          <th className="px-4 sm:px-6 py-4 text-left text-xs sm:text-sm font-medium text-gray-200 uppercase tracking-wider">
                             Name
                           </th>
-                          <th className="px-4 sm:px-6 py-3 text-left text-xs sm:text-sm font-medium text-gray-200 uppercase tracking-wider">
+                          <th className="px-4 sm:px-6 py-4 text-left text-xs sm:text-sm font-medium text-gray-200 uppercase tracking-wider">
                             Email
                           </th>
-                          <th className="px-4 sm:px-6 py-3 text-left text-xs sm:text-sm font-medium text-gray-200 uppercase tracking-wider">
+                          <th className="px-4 sm:px-6 py-4 text-left text-xs sm:text-sm font-medium text-gray-200 uppercase tracking-wider">
                             Role
                           </th>
-                          <th className="px-4 sm:px-6 py-3 text-left text-xs sm:text-sm font-medium text-gray-200 uppercase tracking-wider">
+                          <th className="px-4 sm:px-6 py-4 text-left text-xs sm:text-sm font-medium text-gray-200 uppercase tracking-wider">
                             Actions
                           </th>
                         </tr>
@@ -356,9 +474,9 @@ function AdminDashboardUI() {
                         {allUsers.map((user) => (
                           <tr
                             key={user.id}
-                            className="hover:bg-gray-600/30 transition-colors duration-200"
+                            className="hover:bg-gray-600/40 transition-colors duration-200"
                           >
-                            <td className="px-4 sm:px-6 py-4 text-sm sm:text-base text-white">
+                            <td className="px-4 sm:px-6 py-4 text-sm sm:text-base text-white font-medium">
                               {user.name}
                             </td>
                             <td className="px-4 sm:px-6 py-4 text-sm sm:text-base text-gray-300">
@@ -366,12 +484,12 @@ function AdminDashboardUI() {
                             </td>
                             <td className="px-4 sm:px-6 py-4">
                               <span
-                                className={`px-2 sm:px-3 py-1 rounded-full text-xs sm:text-sm font-medium ${
+                                className={`px-2 sm:px-3 py-1 rounded-full text-xs sm:text-sm font-medium shadow-sm ${
                                   user.role === "admin"
-                                    ? "bg-purple-600 text-white"
+                                    ? "bg-purple-600/80 text-white"
                                     : user.role === "mentor"
-                                    ? "bg-blue-600 text-white"
-                                    : "bg-gray-600 text-white"
+                                    ? "bg-blue-600/80 text-white"
+                                    : "bg-gray-600/80 text-white"
                                 }`}
                               >
                                 {user.role}
@@ -379,10 +497,10 @@ function AdminDashboardUI() {
                             </td>
                             <td className="px-4 sm:px-6 py-4">
                               <button
-                                className={`px-3 sm:px-4 py-1 sm:py-2 rounded text-xs sm:text-sm font-medium transition-colors duration-200 ${
+                                className={`px-3 sm:px-4 py-1 sm:py-2 rounded-lg text-xs sm:text-sm font-medium transition-colors duration-200 shadow-md ${
                                   user.role === "admin"
                                     ? "bg-gray-600 text-gray-400 cursor-not-allowed"
-                                    : "bg-red-600 hover:bg-red-700 text-white"
+                                    : "bg-red-600 hover:bg-red-700 text-white hover:shadow-red-600/30"
                                 }`}
                                 disabled={user.role === "admin"}
                               >
@@ -403,17 +521,32 @@ function AdminDashboardUI() {
 
       {/* Rejection Modal */}
       {isRejectModalOpen && selectedMentor && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-          <div className="bg-gray-800/90 backdrop-blur-md p-6 rounded-2xl w-full max-w-md">
-            <h2 className="text-xl sm:text-2xl font-bold text-white mb-4">
-              Reject Mentor Request
-            </h2>
+        <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50">
+          <div className="bg-gray-800/90 backdrop-blur-md p-6 rounded-2xl w-full max-w-md border border-gray-700/50 shadow-2xl">
+            <div className="flex items-center mb-4">
+              <svg
+                className="w-6 h-6 mr-2 text-red-400"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+                />
+              </svg>
+              <h2 className="text-xl sm:text-2xl font-bold text-white">
+                Reject Mentor Request
+              </h2>
+            </div>
             <p className="text-gray-300 mb-4">
               Specify the reason for rejecting {selectedMentor.name}'s mentor
               request.
             </p>
             <textarea
-              className="w-full h-32 p-3 bg-gray-700/50 text-white rounded-lg border border-gray-600 focus:outline-none focus:border-yellow-400"
+              className="w-full h-32 p-3 bg-gray-700/50 text-white rounded-lg border border-gray-600 focus:outline-none focus:border-yellow-400 transition-all duration-200 resize-none"
               placeholder="Enter rejection reason..."
               value={rejectReason}
               onChange={(e) => setRejectReason(e.target.value)}
@@ -425,13 +558,13 @@ function AdminDashboardUI() {
                   setRejectReason("");
                   setSelectedMentor(null);
                 }}
-                className="bg-gray-600 hover:bg-gray-700 text-white px-4 py-2 rounded text-sm font-medium transition-colors duration-200"
+                className="bg-gray-600 hover:bg-gray-700 text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-200 shadow-md hover:shadow-gray-600/30"
               >
                 Cancel
               </button>
               <button
                 onClick={handleSendRejection}
-                className="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded text-sm font-medium transition-colors duration-200"
+                className="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-200 shadow-md hover:shadow-red-600/30"
               >
                 Send Rejection
               </button>

--- a/src/admin/ViewMentorDetails.jsx
+++ b/src/admin/ViewMentorDetails.jsx
@@ -1,17 +1,56 @@
 import { Link, useParams } from "react-router-dom";
 import Navbar from "../components/layout/Navbar";
 import Footer from "../components/layout/Footer";
+import ReApprovalEmail from "../Services/ReApprovalEmail";
 import React, { useState, useEffect } from "react";
 import { db } from "../BACKEND/firebase";
-import { doc, getDoc, Timestamp } from "firebase/firestore"; // Add Timestamp import
+import { getDoc, Timestamp } from "firebase/firestore";
+import { updateDoc, doc, serverTimestamp } from "firebase/firestore";
+import { auth } from "../BACKEND/firebase"; // admin ka auth
 
 function ViewMentorDetails() {
   const { id } = useParams();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [changesNeeded, setChangesNeeded] = useState("");
+  const [fieldsToChange, setFieldsToChange] = useState([]); // naya
   const [mentor, setMentor] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+
+  function formatTimeTo12Hour(timeString) {
+    const [hours, minutes] = timeString.split(":");
+    const hour = parseInt(hours, 10);
+    const ampm = hour >= 12 ? "PM" : "AM";
+    const formattedHour = hour % 12 || 12;
+    return `${formattedHour}:${minutes} ${ampm}`;
+  }
+
+  const availableFields = [
+    "profilePicture",
+    "professionalTitle",
+    "bio",
+    "skills",
+    "primaryCategory",
+    "experienceLevel",
+    "yearsOfExperience",
+    "highestQualification",
+    "certifications",
+    "resume",
+    "timeSlots",
+    "preferredDays",
+    "timeZone",
+    "sessionPrice",
+    "currency",
+    "sessionDuration",
+    "linkedin",
+    "github",
+    "portfolio",
+    "youtube",
+    "demoVideo",
+    "experience",
+    "teachingStyle",
+    "languages",
+  ];
 
   useEffect(() => {
     const fetchMentorData = async () => {
@@ -35,7 +74,7 @@ function ViewMentorDetails() {
           mobileNumber: userData.mobileNumber || "N/A",
           profilePhoto: userData.profilePhoto || "",
           userType: userData.userType || "pendingMentor",
-          createdAt: userData.createdAt || mentorData.createdAt || "N/A", // Handle Timestamp
+          createdAt: userData.createdAt || mentorData.createdAt || "N/A",
           fullName: mentorData.fullName || userData.name || "N/A",
           professionalTitle: mentorData.professionalTitle || "N/A",
           bio: mentorData.bio || "No bio provided",
@@ -76,61 +115,132 @@ function ViewMentorDetails() {
     fetchMentorData();
   }, [id]);
 
-  const handleRequestReapproval = () => {
-    if (changesNeeded.trim()) {
-      alert(`Re-approval request sent to ${mentor.fullName}: ${changesNeeded}`);
+  const handleRequestReapproval = async () => {
+    if (!changesNeeded.trim() || fieldsToChange.length === 0) {
+      alert("Please specify the fields and reason for re-approval.");
+      return;
+    }
+
+    const adminId = auth.currentUser.uid;
+    const mentorRequestRef = doc(db, "mentorRequest", id);
+
+    try {
+      // Update Firestore
+      await updateDoc(mentorRequestRef, {
+        status: "reapproval_pending",
+        last_updated: serverTimestamp(),
+        updated_by: adminId,
+        reapproval_fields: fieldsToChange,
+        reapproval_reason: changesNeeded,
+      });
+
+      // Prepare Update Link
+      const updateLink = `${import.meta.env.VITE_REACT_APP_BASE_URL}/mentorProfileCreate/${id}`;
+      console.log("Sending updateLink:", updateLink);
+
+      // Send Re-Approval Email
+      await ReApprovalEmail(
+        mentor.email,
+        mentor.fullName,
+        fieldsToChange,
+        changesNeeded,
+        updateLink
+      );
+
+      alert(
+        `Re-approval request and email sent successfully to ${mentor.fullName}`
+      );
       setChangesNeeded("");
+      setFieldsToChange([]);
       setIsModalOpen(false);
-    } else {
-      alert("Please specify the changes needed.");
+    } catch (error) {
+      console.error("Error in re-approval process:", error);
+      alert(`Failed to process re-approval: ${error.message}`);
     }
   };
-
   if (loading) {
     return (
-      <div className="min-h-screen bg-gray-900 text-white flex justify-center items-center">
-        <svg
-          className="animate-spin h-8 w-8 text-yellow-400"
-          viewBox="0 0 24 24"
-        >
-          <circle
-            cx="12"
-            cy="12"
-            r="10"
-            stroke="currentColor"
-            strokeWidth="4"
-            fill="none"
-          />
-          <path fill="currentColor" d="M4 12a8 8 0 018-8v8h-8z" />
-        </svg>
+      <div className="min-h-screen bg-gradient-to-br from-gray-900 to-blue-900 text-white flex justify-center items-center">
+        <div className="flex flex-col items-center">
+          <svg
+            className="animate-spin h-12 w-12 text-yellow-400 mb-4"
+            viewBox="0 0 24 24"
+          >
+            <circle
+              cx="12"
+              cy="12"
+              r="10"
+              stroke="currentColor"
+              strokeWidth="4"
+              fill="none"
+            />
+            <path fill="currentColor" d="M4 12a8 8 0 018-8v8h-8z" />
+          </svg>
+          <p className="text-lg font-medium">Loading mentor details...</p>
+        </div>
       </div>
     );
   }
 
   if (error || !mentor) {
     return (
-      <div className="min-h-screen bg-gray-900 text-gray-200 font-sans flex items-center justify-center">
-        <p className="text-xl text-red-400">{error || "Mentor not found."}</p>
+      <div className="min-h-screen bg-gradient-to-br from-gray-900 to-blue-900 text-gray-200 font-sans flex items-center justify-center">
+        <div className="bg-gray-800/80 p-8 rounded-xl max-w-md text-center">
+          <svg
+            className="w-16 h-16 text-red-400 mx-auto mb-4"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={1.5}
+              d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+            />
+          </svg>
+          <p className="text-xl text-red-400 mb-2 font-medium">
+            {error || "Mentor not found"}
+          </p>
+          <Link
+            to="/adminDashBoard"
+            className="inline-flex items-center text-yellow-400 hover:text-yellow-300 mt-4 transition-colors duration-200"
+          >
+            <svg
+              className="w-5 h-5 mr-2"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M10 19l-7-7m0 0l7-7m-7 7h18"
+              />
+            </svg>
+            Back to Dashboard
+          </Link>
+        </div>
       </div>
     );
   }
 
   return (
-    <div className="min-h-screen bg-gray-900 text-gray-200 font-sans">
+    <div className="min-h-screen bg-gradient-to-br from-gray-900 to-blue-900 text-gray-200 font-sans">
       <Navbar />
-      <section className="pt-24 pb-12 min-h-screen bg-gradient-to-br from-gray-800 via-gray-900 to-blue-900">
+      <section className="pt-24 pb-12 min-h-screen">
         <div className="container lg:mt-6 mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="max-w-6xl mx-auto">
+          <div className="max-w-7xl mx-auto">
             <Link
               to="/adminDashBoard"
-              className="inline-flex items-center text-yellow-400 hover:text-yellow-300 mb-6 transition-colors duration-200"
+              className="inline-flex items-center text-yellow-400 hover:text-yellow-300 mb-8 transition-colors duration-200 group"
             >
               <svg
-                className="w-5 h-5 mr-2"
+                className="w-5 h-5 mr-2 group-hover:-translate-x-1 transition-transform duration-200"
                 fill="none"
                 stroke="currentColor"
                 viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
               >
                 <path
                   strokeLinecap="round"
@@ -142,115 +252,188 @@ function ViewMentorDetails() {
               Back to Dashboard
             </Link>
 
-            <div className="bg-gray-800/80 backdrop-blur-md rounded-2xl shadow-xl overflow-hidden">
-              {/* Mentor Header */}
-              <div className="bg-gray-700/50 px-6 py-8 sm:px-10 sm:py-12 flex flex-col sm:flex-row items-start sm:items-center">
-                <div className="flex-shrink-0 mb-6 sm:mb-0 sm:mr-8">
-                  {mentor.profilePhoto ? (
-                    <img
-                      src={mentor.profilePhoto}
-                      alt={mentor.fullName}
-                      className="h-32 w-32 rounded-full object-cover"
-                    />
-                  ) : (
-                    <div className="h-32 w-32 rounded-full bg-gray-600 flex items-center justify-center text-4xl font-bold text-white">
-                      {mentor.fullName
-                        .split(" ")
-                        .map((n) => n[0])
-                        .join("")}
+            {/* Mentor Profile Card */}
+            <div className="bg-gray-800/80 backdrop-blur-lg rounded-2xl shadow-2xl overflow-hidden border border-gray-700/50">
+              {/* Profile Header */}
+              <div className="relative">
+                <div className="absolute inset-0 bg-gradient-to-r from-yellow-600/20 to-blue-600/20"></div>
+                <div className="relative px-6 py-8 sm:px-10 sm:py-12 flex flex-col sm:flex-row items-start sm:items-center gap-6">
+                  <div className="flex-shrink-0 relative">
+                    {mentor.profilePhoto ? (
+                      <img
+                        src={mentor.profilePhoto}
+                        alt={mentor.fullName}
+                        className="h-36 w-36 rounded-full object-cover border-4 border-gray-700/50 shadow-lg"
+                      />
+                    ) : (
+                      <div className="h-36 w-36 rounded-full bg-gray-700 flex items-center justify-center text-5xl font-bold text-white border-4 border-gray-700/50 shadow-lg">
+                        {mentor.fullName
+                          .split(" ")
+                          .map((n) => n[0])
+                          .join("")}
+                      </div>
+                    )}
+                    <div className="absolute -bottom-2 -right-2 bg-blue-600 rounded-full px-3 py-1 text-xs font-bold shadow-md">
+                      {mentor.userType.replace(/([A-Z])/g, " $1").trim()}
                     </div>
-                  )}
-                </div>
-                <div className="flex-grow">
-                  <h1 className="text-3xl sm:text-4xl font-bold text-white mb-2">
-                    {mentor.fullName}
-                  </h1>
-                  <p className="text-yellow-400 text-lg mb-2">
-                    {mentor.professionalTitle}
-                  </p>
-                  <p className="text-gray-300 text-sm mb-2">{mentor.email}</p>
-                  <p className="text-gray-300 text-sm mb-4">
-                    {mentor.mobileNumber}
-                  </p>
-                  <div className="flex flex-wrap gap-2 mb-4">
-                    <span className="bg-blue-600 text-white px-3 py-1 rounded-full text-sm">
-                      {mentor.yearsOfExperience} Experience
-                    </span>
-                    <span className="bg-green-600 text-white px-3 py-1 rounded-full text-sm">
-                      {mentor.primaryCategory}
-                    </span>
-                    <span className="bg-yellow-600 text-white px-3 py-1 rounded-full text-sm">
-                      {mentor.experienceLevel}
-                    </span>
-                    <span className="bg-purple-600 text-white px-3 py-1 rounded-full text-sm capitalize">
-                      {mentor.userType}
-                    </span>
                   </div>
-                  <div className="flex flex-wrap gap-4">
-                    <button
-                      onClick={() => setIsModalOpen(true)}
-                      className="bg-yellow-600 hover:bg-yellow-700 text-white px-4 py-2 rounded text-sm font-medium transition-colors duration-200"
-                    >
-                      Request Re-approval
-                    </button>
-                    <button className="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded text-sm font-medium transition-colors duration-200">
-                      Remove Mentor
-                    </button>
+                  <div className="flex-grow space-y-3">
+                    <div>
+                      <h1 className="text-3xl sm:text-4xl font-bold text-white mb-1">
+                        {mentor.fullName}
+                      </h1>
+                      <p className="text-yellow-400 text-lg font-medium">
+                        {mentor.professionalTitle}
+                      </p>
+                    </div>
+
+                    <div className="flex flex-wrap gap-2">
+                      <span className="bg-blue-600/80 text-white px-3 py-1 rounded-full text-xs font-medium flex items-center">
+                        <svg
+                          className="w-3 h-3 mr-1"
+                          fill="currentColor"
+                          viewBox="0 0 20 20"
+                        >
+                          <path
+                            fillRule="evenodd"
+                            d="M6 2a1 1 0 00-1 1v1H4a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V6a2 2 0 00-2-2h-1V3a1 1 0 10-2 0v1H7V3a1 1 0 00-1-1zm0 5a1 1 0 000 2h8a1 1 0 100-2H6z"
+                            clipRule="evenodd"
+                          />
+                        </svg>
+                        {mentor.yearsOfExperience} yrs exp
+                      </span>
+                      <span className="bg-purple-600/80 text-white px-3 py-1 rounded-full text-xs font-medium">
+                        {mentor.primaryCategory}
+                      </span>
+                      <span className="bg-green-600/80 text-white px-3 py-1 rounded-full text-xs font-medium">
+                        {mentor.experienceLevel}
+                      </span>
+                    </div>
+
+                    <div className="flex flex-wrap gap-3 pt-2">
+                      <button
+                        onClick={() => setIsModalOpen(true)}
+                        className="bg-yellow-600 hover:bg-yellow-700 text-white px-4 py-2 rounded-lg text-sm font-medium transition-all duration-200 flex items-center shadow-md hover:shadow-yellow-600/20"
+                      >
+                        <svg
+                          className="w-4 h-4 mr-2"
+                          fill="none"
+                          stroke="currentColor"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={2}
+                            d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
+                          />
+                        </svg>
+                        Request Re-approval
+                      </button>
+                      <button className="bg-red-600/90 hover:bg-red-700 text-white px-4 py-2 rounded-lg text-sm font-medium transition-all duration-200 flex items-center shadow-md hover:shadow-red-600/20">
+                        <svg
+                          className="w-4 h-4 mr-2"
+                          fill="none"
+                          stroke="currentColor"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={2}
+                            d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                          />
+                        </svg>
+                        Remove Mentor
+                      </button>
+                    </div>
                   </div>
                 </div>
               </div>
 
               {/* Main Content */}
-              <div className="p-6 sm:p-10 grid grid-cols-1 lg:grid-cols-3 gap-8">
+              <div className="p-6 sm:p-8 grid grid-cols-1 lg:grid-cols-3 gap-8">
                 {/* Left Column */}
-                <div className="lg:col-span-2 space-y-8">
+                <div className="lg:col-span-2 space-y-6">
                   {/* About Section */}
-                  <div className="bg-gray-700/50 backdrop-blur-sm p-6 rounded-lg shadow-md transition-all duration-300 hover:shadow-lg">
-                    <h2 className="text-xl sm:text-2xl font-bold text-white mb-4 border-b border-gray-600 pb-2">
-                      About
-                    </h2>
-                    <p className="text-gray-300">{mentor.bio}</p>
-                    <div className="mt-4">
-                      <h3 className="text-sm font-semibold text-gray-400">
-                        Teaching Style
-                      </h3>
-                      <p className="text-white">{mentor.teachingStyle}</p>
+                  <div className="bg-gray-700/50 backdrop-blur-sm p-6 rounded-xl shadow-lg border border-gray-600/20 transition-all duration-300 hover:border-yellow-500/30">
+                    <div className="flex items-center mb-4">
+                      <div className="w-1.5 h-6 bg-yellow-500 rounded-full mr-3"></div>
+                      <h2 className="text-xl font-bold text-white">
+                        About & Bio
+                      </h2>
                     </div>
-                    <div className="mt-4">
-                      <h3 className="text-sm font-semibold text-gray-400">
-                        Experience
-                      </h3>
-                      <p className="text-white">{mentor.experience}</p>
+                    <p className="text-gray-300 leading-relaxed mb-4">
+                      {mentor.bio}
+                    </p>
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                      <div>
+                        <h3 className="text-sm font-semibold text-gray-400 mb-1">
+                          Teaching Style
+                        </h3>
+                        <p className="text-white font-medium">
+                          {mentor.teachingStyle}
+                        </p>
+                      </div>
+                      <div>
+                        <h3 className="text-sm font-semibold text-gray-400 mb-1">
+                          Experience
+                        </h3>
+                        <p className="text-white font-medium">
+                          {mentor.experience}
+                        </p>
+                      </div>
                     </div>
                   </div>
 
                   {/* Expertise Section */}
-                  <div className="bg-gray-700/50 backdrop-blur-sm p-6 rounded-lg shadow-md transition-all duration-300 hover:shadow-lg">
-                    <h2 className="text-xl sm:text-2xl font-bold text-white mb-4 border-b border-gray-600 pb-2">
-                      Expertise
-                    </h2>
-                    <div className="flex flex-wrap gap-2 mb-4">
-                      {mentor.skills.map((skill, index) => (
-                        <span
-                          key={index}
-                          className="bg-gray-600 text-white px-3 py-1 rounded-full text-sm"
-                        >
-                          {skill}
-                        </span>
-                      ))}
+                  <div className="bg-gray-700/50 backdrop-blur-sm p-6 rounded-xl shadow-lg border border-gray-600/20 transition-all duration-300 hover:border-blue-500/30">
+                    <div className="flex items-center mb-4">
+                      <div className="w-1.5 h-6 bg-blue-500 rounded-full mr-3"></div>
+                      <h2 className="text-xl font-bold text-white">
+                        Expertise
+                      </h2>
                     </div>
-                    <div className="mt-4">
-                      <h3 className="text-sm font-semibold text-gray-400">
+                    <div className="mb-6">
+                      <h3 className="text-sm font-semibold text-gray-400 mb-2">
+                        Skills & Technologies
+                      </h3>
+                      <div className="flex flex-wrap gap-2">
+                        {mentor.skills.map((skill, index) => (
+                          <span
+                            key={index}
+                            className="bg-gray-600/70 text-white px-3 py-1 rounded-full text-xs font-medium hover:bg-gray-500/70 transition-colors duration-200"
+                          >
+                            {skill}
+                          </span>
+                        ))}
+                      </div>
+                    </div>
+                    <div>
+                      <h3 className="text-sm font-semibold text-gray-400 mb-2">
                         Certifications
                       </h3>
                       {mentor.certifications.length > 0 ? (
-                        <ul className="list-disc list-inside text-white">
+                        <ul className="space-y-2">
                           {mentor.certifications.map((cert, index) => (
-                            <li key={index}>{cert}</li>
+                            <li key={index} className="flex items-start">
+                              <svg
+                                className="w-4 h-4 text-yellow-400 mt-0.5 mr-2 flex-shrink-0"
+                                fill="currentColor"
+                                viewBox="0 0 20 20"
+                              >
+                                <path
+                                  fillRule="evenodd"
+                                  d="M6.267 3.455a3.066 3.066 0 001.745-.723 3.066 3.066 0 013.976 0 3.066 3.066 0 001.745.723 3.066 3.066 0 012.812 2.812c.051.643.304 1.254.723 1.745a3.066 3.066 0 010 3.976 3.066 3.066 0 00-.723 1.745 3.066 3.066 0 01-2.812 2.812 3.066 3.066 0 00-1.745.723 3.066 3.066 0 01-3.976 0 3.066 3.066 0 00-1.745-.723 3.066 3.066 0 01-2.812-2.812 3.066 3.066 0 00-.723-1.745 3.066 3.066 0 010-3.976 3.066 3.066 0 00.723-1.745 3.066 3.066 0 012.812-2.812zm7.44 5.252a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
+                                  clipRule="evenodd"
+                                />
+                              </svg>
+                              <span className="text-white">{cert}</span>
+                            </li>
                           ))}
                         </ul>
                       ) : (
-                        <p className="text-gray-400">
+                        <p className="text-gray-400 italic">
                           No certifications provided
                         </p>
                       )}
@@ -258,63 +441,89 @@ function ViewMentorDetails() {
                   </div>
 
                   {/* Availability Section */}
-                  <div className="bg-gray-700/50 backdrop-blur-sm p-6 rounded-lg shadow-md transition-all duration-300 hover:shadow-lg">
-                    <h2 className="text-xl sm:text-2xl font-bold text-white mb-4 border-b border-gray-600 pb-2">
-                      Availability & Pricing
-                    </h2>
-                    <div className="space-y-4">
-                      <div>
-                        <h3 className="text-sm font-semibold text-gray-400">
-                          Time Slots
-                        </h3>
-                        <p className="text-white">
-                          {mentor.timeSlots.join(", ") || "N/A"}
-                        </p>
+                  <div className="bg-gray-700/50 backdrop-blur-sm p-6 rounded-xl shadow-lg border border-gray-600/20 transition-all duration-300 hover:border-green-500/30">
+                    <div className="flex items-center mb-4">
+                      <div className="w-1.5 h-6 bg-green-500 rounded-full mr-3"></div>
+                      <h2 className="text-xl font-bold text-white">
+                        Availability & Pricing
+                      </h2>
+                    </div>
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                      <div className="space-y-3">
+                        <div>
+                          <h3 className="text-sm font-semibold text-gray-400 mb-1">
+                            Time Slots
+                          </h3>
+                          <div className="text-white font-medium">
+                            {mentor.timeSlots && mentor.timeSlots.length > 0 ? (
+                              <ul className="space-y-1">
+                                {mentor.timeSlots.map((slot, index) => (
+                                  <li key={index}>
+                                    {slot.day}:{" "}
+                                    {formatTimeTo12Hour(slot.startTime)} -{" "}
+                                    {formatTimeTo12Hour(slot.endTime)}
+                                  </li>
+                                ))}
+                              </ul>
+                            ) : (
+                              "Not specified"
+                            )}
+                          </div>
+                        </div>
+                        <div>
+                          <h3 className="text-sm font-semibold text-gray-400 mb-1">
+                            Preferred Days
+                          </h3>
+                          <p className="text-white font-medium">
+                            {mentor.preferredDays.join(", ") || "Flexible"}
+                          </p>
+                        </div>
                       </div>
-                      <div>
-                        <h3 className="text-sm font-semibold text-gray-400">
-                          Preferred Days
-                        </h3>
-                        <p className="text-white">
-                          {mentor.preferredDays.join(", ") || "N/A"}
-                        </p>
-                      </div>
-                      <div>
-                        <h3 className="text-sm font-semibold text-gray-400">
-                          Time Zone
-                        </h3>
-                        <p className="text-white">{mentor.timeZone}</p>
-                      </div>
-                      <div>
-                        <h3 className="text-sm font-semibold text-gray-400">
-                          Session Pricing
-                        </h3>
-                        <p className="text-white">
-                          {mentor.sessionPrice} {mentor.currency} for{" "}
-                          {mentor.sessionDuration} minutes
-                        </p>
+                      <div className="space-y-3">
+                        <div>
+                          <h3 className="text-sm font-semibold text-gray-400 mb-1">
+                            Time Zone
+                          </h3>
+                          <p className="text-white font-medium">
+                            {mentor.timeZone}
+                          </p>
+                        </div>
+                        <div>
+                          <h3 className="text-sm font-semibold text-gray-400 mb-1">
+                            Session Pricing
+                          </h3>
+                          <p className="text-white font-medium">
+                            <span className="text-yellow-400">
+                              {mentor.sessionPrice} {mentor.currency}
+                            </span>{" "}
+                            for {mentor.sessionDuration} minutes
+                          </p>
+                        </div>
                       </div>
                     </div>
                   </div>
 
                   {/* Demo Video */}
-                  <div className="bg-gray-700/50 backdrop-blur-sm p-6 rounded-lg shadow-md transition-all duration-300 hover:shadow-lg">
-                    <h2 className="text-xl sm:text-2xl font-bold text-white mb-4 border-b border-gray-600 pb-2">
-                      Demo Video
-                    </h2>
+                  <div className="bg-gray-700/50 backdrop-blur-sm p-6 rounded-xl shadow-lg border border-gray-600/20 transition-all duration-300 hover:border-red-500/30">
+                    <div className="flex items-center mb-4">
+                      <div className="w-1.5 h-6 bg-red-500 rounded-full mr-3"></div>
+                      <h2 className="text-xl font-bold text-white">
+                        Demo Video
+                      </h2>
+                    </div>
                     <div className="aspect-w-16 aspect-h-9 bg-gray-800 rounded-lg overflow-hidden flex items-center justify-center">
                       {mentor.demoVideo ? (
-                        <video controls className="w-full h-full">
+                        <video controls className="w-full h-full rounded-lg">
                           <source src={mentor.demoVideo} type="video/mp4" />
+                          Your browser does not support the video tag.
                         </video>
                       ) : (
                         <div className="text-gray-400 p-8 text-center">
                           <svg
-                            className="w-12 h-12 mx-auto mb-2"
+                            className="w-12 h-12 mx-auto mb-3 text-gray-500"
                             fill="none"
                             stroke="currentColor"
                             viewBox="0 0 24 24"
-                            xmlns="http://www.w3.org/2000/svg"
                           >
                             <path
                               strokeLinecap="round"
@@ -323,7 +532,7 @@ function ViewMentorDetails() {
                               d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z"
                             />
                           </svg>
-                          <p>No video uploaded</p>
+                          <p className="text-sm">No demo video uploaded</p>
                         </div>
                       )}
                     </div>
@@ -331,94 +540,180 @@ function ViewMentorDetails() {
                 </div>
 
                 {/* Right Column */}
-                <div className="space-y-8">
+                <div className="space-y-6">
                   {/* Contact Details Card */}
-                  <div className="bg-gray-700/50 backdrop-blur-sm p-6 rounded-lg shadow-md transition-all duration-300 hover:shadow-lg">
-                    <h2 className="text-xl sm:text-2xl font-bold text-white mb-4 border-b border-gray-600 pb-2">
-                      Contact Details
-                    </h2>
+                  <div className="bg-gray-700/50 backdrop-blur-sm p-6 rounded-xl shadow-lg border border-gray-600/20 transition-all duration-300 hover:border-purple-500/30">
+                    <div className="flex items-center mb-4">
+                      <div className="w-1.5 h-6 bg-purple-500 rounded-full mr-3"></div>
+                      <h2 className="text-xl font-bold text-white">
+                        Contact Details
+                      </h2>
+                    </div>
                     <div className="space-y-4">
                       <div>
-                        <h3 className="text-sm font-semibold text-gray-400">
+                        <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-1">
                           Email
                         </h3>
-                        <p className="text-white">{mentor.email}</p>
+                        <div className="flex items-center">
+                          <svg
+                            className="w-4 h-4 text-gray-400 mr-2"
+                            fill="currentColor"
+                            viewBox="0 0 20 20"
+                          >
+                            <path d="M2.003 5.884L10 9.882l7.997-3.998A2 2 0 0016 4H4a2 2 0 00-1.997 1.884z" />
+                            <path d="M18 8.118l-8 4-8-4V14a2 2 0 002 2h12a2 2 0 002-2V8.118z" />
+                          </svg>
+                          <p className="text-white font-medium">
+                            {mentor.email}
+                          </p>
+                        </div>
                       </div>
                       <div>
-                        <h3 className="text-sm font-semibold text-gray-400">
+                        <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-1">
                           Email Verified
                         </h3>
-                        <p className="text-white">
-                          {mentor.emailVerified ? "Yes" : "No"}
-                        </p>
+                        <div className="flex items-center">
+                          {mentor.emailVerified ? (
+                            <>
+                              <svg
+                                className="w-4 h-4 text-green-400 mr-2"
+                                fill="currentColor"
+                                viewBox="0 0 20 20"
+                              >
+                                <path
+                                  fillRule="evenodd"
+                                  d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
+                                  clipRule="evenodd"
+                                />
+                              </svg>
+                              <span className="text-green-400 font-medium">
+                                Verified
+                              </span>
+                            </>
+                          ) : (
+                            <>
+                              <svg
+                                className="w-4 h-4 text-red-400 mr-2"
+                                fill="currentColor"
+                                viewBox="0 0 20 20"
+                              >
+                                <path
+                                  fillRule="evenodd"
+                                  d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z"
+                                  clipRule="evenodd"
+                                />
+                              </svg>
+                              <span className="text-red-400 font-medium">
+                                Not Verified
+                              </span>
+                            </>
+                          )}
+                        </div>
                       </div>
                       <div>
-                        <h3 className="text-sm font-semibold text-gray-400">
+                        <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-1">
                           Mobile Number
                         </h3>
-                        <p className="text-white">{mentor.mobileNumber}</p>
+                        <div className="flex items-center">
+                          <svg
+                            className="w-4 h-4 text-gray-400 mr-2"
+                            fill="currentColor"
+                            viewBox="0 0 20 20"
+                          >
+                            <path d="M2 3a1 1 0 011-1h2.153a1 1 0 01.986.836l.74 4.435a1 1 0 01-.54 1.06l-1.548.773a11.037 11.037 0 006.105 6.105l.774-1.548a1 1 0 011.059-.54l4.435.74a1 1 0 01.836.986V17a1 1 0 01-1 1h-2C7.82 18 2 12.18 2 5V3z" />
+                          </svg>
+                          <p className="text-white font-medium">
+                            {mentor.mobileNumber}
+                          </p>
+                        </div>
                       </div>
                       <div>
-                        <h3 className="text-sm font-semibold text-gray-400">
-                          Created At
+                        <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-1">
+                          Joined On
                         </h3>
-                        <p className="text-white">
-                          {mentor.createdAt instanceof Timestamp
-                            ? mentor.createdAt.toDate().toLocaleString()
-                            : mentor.createdAt || "N/A"}
-                        </p>
-                      </div>
-                      <div>
-                        <h3 className="text-sm font-semibold text-gray-400">
-                          User Type
-                        </h3>
-                        <p className="text-white capitalize">
-                          {mentor.userType}
-                        </p>
+                        <div className="flex items-center">
+                          <svg
+                            className="w-4 h-4 text-gray-400 mr-2"
+                            fill="currentColor"
+                            viewBox="0 0 20 20"
+                          >
+                            <path
+                              fillRule="evenodd"
+                              d="M6 2a1 1 0 00-1 1v1H4a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V6a2 2 0 00-2-2h-1V3a1 1 0 10-2 0v1H7V3a1 1 0 00-1-1zm0 5a1 1 0 000 2h8a1 1 0 100-2H6z"
+                              clipRule="evenodd"
+                            />
+                          </svg>
+                          <p className="text-white font-medium">
+                            {mentor.createdAt instanceof Timestamp
+                              ? mentor.createdAt.toDate().toLocaleDateString()
+                              : mentor.createdAt || "N/A"}
+                          </p>
+                        </div>
                       </div>
                     </div>
                   </div>
 
                   {/* Education Card */}
-                  <div className="bg-gray-700/50 backdrop-blur-sm p-6 rounded-lg shadow-md transition-all duration-300 hover:shadow-lg">
-                    <h2 className="text-xl sm:text-2xl font-bold text-white mb-4 border-b border-gray-600 pb-2">
-                      Education
-                    </h2>
+                  <div className="bg-gray-700/50 backdrop-blur-sm p-6 rounded-xl shadow-lg border border-gray-600/20 transition-all duration-300 hover:border-blue-500/30">
+                    <div className="flex items-center mb-4">
+                      <div className="w-1.5 h-6 bg-blue-400 rounded-full mr-3"></div>
+                      <h2 className="text-xl font-bold text-white">
+                        Education
+                      </h2>
+                    </div>
                     <div className="space-y-4">
                       <div>
-                        <h3 className="text-sm font-semibold text-gray-400">
+                        <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-1">
                           Highest Qualification
                         </h3>
-                        <p className="text-white">
-                          {mentor.highestQualification}
-                        </p>
+                        <div className="flex items-center">
+                          <svg
+                            className="w-4 h-4 text-gray-400 mr-2"
+                            fill="currentColor"
+                            viewBox="0 0 20 20"
+                          >
+                            <path d="M10.394 2.08a1 1 0 00-.788 0l-7 3a1 1 0 000 1.84L5.25 8.051a.999.999 0 01.356-.257l4-1.714a1 1 0 11.788 1.838L7.667 9.088l1.94.831a1 1 0 00.787 0l7-3a1 1 0 000-1.838l-7-3zM3.31 9.397L5 10.12v4.102a8.969 8.969 0 00-1.05-.174 1 1 0 01-.89-.89 11.115 11.115 0 01.25-3.762zM9.3 16.573A9.026 9.026 0 007 14.935v-3.957l1.818.78a3 3 0 002.364 0l5.508-2.361a11.026 11.026 0 01.25 3.762 1 1 0 01-.89.89 8.968 8.968 0 00-5.35 2.524 1 1 0 01-1.4 0zM6 18a1 1 0 001-1v-2.065a8.935 8.935 0 00-2-.712V17a1 1 0 001 1z" />
+                          </svg>
+                          <p className="text-white font-medium">
+                            {mentor.highestQualification}
+                          </p>
+                        </div>
                       </div>
                       <div>
-                        <h3 className="text-sm font-semibold text-gray-400">
+                        <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-1">
                           Languages
                         </h3>
-                        <p className="text-white">
-                          {mentor.languages.join(", ") || "N/A"}
-                        </p>
+                        <div className="flex flex-wrap gap-2">
+                          {mentor.languages.map((lang, index) => (
+                            <span
+                              key={index}
+                              className="bg-gray-600/70 text-white px-2.5 py-1 rounded-full text-xs font-medium"
+                            >
+                              {lang}
+                            </span>
+                          ))}
+                        </div>
                       </div>
                     </div>
                   </div>
 
                   {/* Documents Card */}
-                  <div className="bg-gray-700/50 backdrop-blur-sm p-6 rounded-lg shadow-md transition-all duration-300 hover:shadow-lg">
-                    <h2 className="text-xl sm:text-2xl font-bold text-white mb-4 border-b border-gray-600 pb-2">
-                      Documents
-                    </h2>
+                  <div className="bg-gray-700/50 backdrop-blur-sm p-6 rounded-xl shadow-lg border border-gray-600/20 transition-all duration-300 hover:border-green-500/30">
+                    <div className="flex items-center mb-4">
+                      <div className="w-1.5 h-6 bg-green-400 rounded-full mr-3"></div>
+                      <h2 className="text-xl font-bold text-white">
+                        Documents
+                      </h2>
+                    </div>
                     <div className="space-y-3">
                       {mentor.resume ? (
-                        <div className="flex items-center justify-between bg-gray-600/50 p-3 rounded">
+                        <div className="flex items-center justify-between bg-gray-600/30 hover:bg-gray-600/50 p-3 rounded-lg transition-colors duration-200">
                           <div className="flex items-center">
                             <svg
-                              className="w-5 h-5 mr-2 text-gray-400"
+                              className="w-5 h-5 mr-2 text-yellow-400"
                               fill="none"
                               stroke="currentColor"
                               viewBox="0 0 24 24"
-                              xmlns="http://www.w3.org/2000/svg"
                             >
                               <path
                                 strokeLinecap="round"
@@ -427,59 +722,100 @@ function ViewMentorDetails() {
                                 d="M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z"
                               />
                             </svg>
-                            <span className="text-white">{mentor.resume}</span>
+                            <span className="text-white font-medium truncate max-w-xs">
+                              {mentor.resume}
+                            </span>
                           </div>
                           <a
-                            href="#"
+                            href={mentor.resume}
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="text-blue-400 hover:text-blue-300"
+                            className="text-blue-400 hover:text-blue-300 ml-2"
                           >
-                            View
+                            <svg
+                              className="w-5 h-5"
+                              fill="none"
+                              stroke="currentColor"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                strokeWidth={2}
+                                d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+                              />
+                              <path
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                strokeWidth={2}
+                                d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+                              />
+                            </svg>
                           </a>
                         </div>
                       ) : (
-                        <p className="text-gray-400">No resume uploaded</p>
+                        <div className="text-center py-4">
+                          <svg
+                            className="w-8 h-8 mx-auto text-gray-500 mb-2"
+                            fill="none"
+                            stroke="currentColor"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              strokeWidth={1.5}
+                              d="M9 13h6m-3-3v6m-9 1V7a2 2 0 012-2h6l2 2h6a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2z"
+                            />
+                          </svg>
+                          <p className="text-gray-400 text-sm">
+                            No resume uploaded
+                          </p>
+                        </div>
                       )}
                     </div>
                   </div>
 
                   {/* Social Links Card */}
-                  <div className="bg-gray-700/50 backdrop-blur-sm p-6 rounded-lg shadow-md transition-all duration-300 hover:shadow-lg">
-                    <h2 className="text-xl sm:text-2xl font-bold text-white mb-4 border-b border-gray-600 pb-2">
-                      Social Links
-                    </h2>
+                  <div className="bg-gray-700/50 backdrop-blur-sm p-6 rounded-xl shadow-lg border border-gray-600/20 transition-all duration-300 hover:border-yellow-500/30">
+                    <div className="flex items-center mb-4">
+                      <div className="w-1.5 h-6 bg-yellow-400 rounded-full mr-3"></div>
+                      <h2 className="text-xl font-bold text-white">
+                        Social Links
+                      </h2>
+                    </div>
                     <div className="space-y-3">
-                      {mentor.linkedin && (
+                      {mentor.linkedin ? (
                         <a
                           href={mentor.linkedin}
                           target="_blank"
                           rel="noopener noreferrer"
-                          className="flex items-center text-blue-400 hover:text-blue-300"
+                          className="flex items-center text-blue-400 hover:text-blue-300 p-3 bg-gray-600/30 hover:bg-gray-600/50 rounded-lg transition-colors duration-200"
                         >
                           <svg
-                            className="w-5 h-5 mr-2"
+                            className="w-5 h-5 mr-3"
                             fill="currentColor"
                             viewBox="0 0 24 24"
-                            xmlns="http://www.w3.org/2000/svg"
                           >
                             <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
                           </svg>
-                          LinkedIn Profile
+                          <span className="text-sm font-medium">
+                            LinkedIn Profile
+                          </span>
                         </a>
-                      )}
-                      {mentor.github && (
+                      ) : null}
+
+                      {mentor.github ? (
                         <a
                           href={mentor.github}
                           target="_blank"
                           rel="noopener noreferrer"
-                          className="flex items-center text-gray-400 hover:text-white"
+                          className="flex items-center text-gray-400 hover:text-white p-3 bg-gray-600/30 hover:bg-gray-600/50 rounded-lg transition-colors duration-200"
                         >
                           <svg
-                            className="w-5 h-5 mr-2"
+                            className="w-5 h-5 mr-3"
                             fill="currentColor"
                             viewBox="0 0 24 24"
-                            xmlns="http://www.w3.org/2000/svg"
                           >
                             <path
                               fillRule="evenodd"
@@ -487,22 +823,24 @@ function ViewMentorDetails() {
                               d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"
                             />
                           </svg>
-                          GitHub Profile
+                          <span className="text-sm font-medium">
+                            GitHub Profile
+                          </span>
                         </a>
-                      )}
-                      {mentor.portfolio && (
+                      ) : null}
+
+                      {mentor.portfolio ? (
                         <a
                           href={mentor.portfolio}
                           target="_blank"
                           rel="noopener noreferrer"
-                          className="flex items-center text-blue-400 hover:text-blue-300"
+                          className="flex items-center text-blue-400 hover:text-blue-300 p-3 bg-gray-600/30 hover:bg-gray-600/50 rounded-lg transition-colors duration-200"
                         >
                           <svg
-                            className="w-5 h-5 mr-2"
+                            className="w-5 h-5 mr-3"
                             fill="none"
                             stroke="currentColor"
                             viewBox="0 0 24 24"
-                            xmlns="http://www.w3.org/2000/svg"
                           >
                             <path
                               strokeLinecap="round"
@@ -511,59 +849,148 @@ function ViewMentorDetails() {
                               d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-24.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9"
                             />
                           </svg>
-                          Portfolio
+                          <span className="text-sm font-medium">Portfolio</span>
                         </a>
-                      )}
-                      {mentor.youtube && (
+                      ) : null}
+
+                      {mentor.youtube ? (
                         <a
                           href={mentor.youtube}
                           target="_blank"
                           rel="noopener noreferrer"
-                          className="flex items-center text-red-400 hover:text-red-300"
+                          className="flex items-center text-red-400 hover:text-red-300 p-3 bg-gray-600/30 hover:bg-gray-600/50 rounded-lg transition-colors duration-200"
                         >
                           <svg
-                            className="w-5 h-5 mr-2"
+                            className="w-5 h-5 mr-3"
                             fill="currentColor"
                             viewBox="0 0 24 24"
-                            xmlns="http://www.w3.org/2000/svg"
                           >
                             <path d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.016 3.016 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.377.505 9.377.505s7.505 0 9.377-.505a3.016 3.016 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z" />
                           </svg>
-                          YouTube Channel
+                          <span className="text-sm font-medium">
+                            YouTube Channel
+                          </span>
                         </a>
-                      )}
+                      ) : null}
+
                       {!mentor.linkedin &&
                         !mentor.github &&
                         !mentor.portfolio &&
                         !mentor.youtube && (
-                          <p className="text-gray-400">
-                            No social links provided
-                          </p>
+                          <div className="text-center py-4">
+                            <svg
+                              className="w-8 h-8 mx-auto text-gray-500 mb-2"
+                              fill="none"
+                              stroke="currentColor"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                strokeWidth={1.5}
+                                d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"
+                              />
+                            </svg>
+                            <p className="text-gray-400 text-sm">
+                              No social links provided
+                            </p>
+                          </div>
                         )}
                     </div>
                   </div>
 
-                  {/* Terms Card */}
-                  <div className="bg-gray-700/50 backdrop-blur-sm p-6 rounded-lg shadow-md transition-all duration-300 hover:shadow-lg">
-                    <h2 className="text-xl sm:text-2xl font-bold text-white mb-4 border-b border-gray-600 pb-2">
-                      Terms & Agreements
-                    </h2>
+                  {/* Terms & Agreements Card */}
+                  <div className="bg-gray-700/50 backdrop-blur-sm p-6 rounded-xl shadow-lg border border-gray-600/20 transition-all duration-300 hover:border-purple-500/30">
+                    <div className="flex items-center mb-4">
+                      <div className="w-1.5 h-6 bg-purple-500 rounded-full mr-3"></div>
+                      <h2 className="text-xl font-bold text-white">
+                        Terms & Agreements
+                      </h2>
+                    </div>
                     <div className="space-y-4">
                       <div>
-                        <h3 className="text-sm font-semibold text-gray-400">
+                        <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-1">
                           Agreed to Terms
                         </h3>
-                        <p className="text-white">
-                          {mentor.agreedToTerms ? "Yes" : "No"}
-                        </p>
+                        <div className="flex items-center">
+                          {mentor.agreedToTerms ? (
+                            <>
+                              <svg
+                                className="w-4 h-4 text-green-400 mr-2"
+                                fill="currentColor"
+                                viewBox="0 0 20 20"
+                              >
+                                <path
+                                  fillRule="evenodd"
+                                  d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
+                                  clipRule="evenodd"
+                                />
+                              </svg>
+                              <span className="text-green-400 font-medium">
+                                Agreed
+                              </span>
+                            </>
+                          ) : (
+                            <>
+                              <svg
+                                className="w-4 h-4 text-red-400 mr-2"
+                                fill="currentColor"
+                                viewBox="0 0 20 20"
+                              >
+                                <path
+                                  fillRule="evenodd"
+                                  d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z"
+                                  clipRule="evenodd"
+                                />
+                              </svg>
+                              <span className="text-red-400 font-medium">
+                                Not Agreed
+                              </span>
+                            </>
+                          )}
+                        </div>
                       </div>
                       <div>
-                        <h3 className="text-sm font-semibold text-gray-400">
+                        <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-1">
                           Agreed to NDA
                         </h3>
-                        <p className="text-white">
-                          {mentor.agreedToNDA ? "Yes" : "No"}
-                        </p>
+                        <div className="flex items-center">
+                          {mentor.agreedToNDA ? (
+                            <>
+                              <svg
+                                className="w-4 h-4 text-green-400 mr-2"
+                                fill="currentColor"
+                                viewBox="0 0 20 20"
+                              >
+                                <path
+                                  fillRule="evenodd"
+                                  d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
+                                  clipRule="evenodd"
+                                />
+                              </svg>
+                              <span className="text-green-400 font-medium">
+                                Agreed
+                              </span>
+                            </>
+                          ) : (
+                            <>
+                              <svg
+                                className="w-4 h-4 text-red-400 mr-2"
+                                fill="currentColor"
+                                viewBox="0 0 20 20"
+                              >
+                                <path
+                                  fillRule="evenodd"
+                                  d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z"
+                                  clipRule="evenodd"
+                                />
+                              </svg>
+                              <span className="text-red-400 font-medium">
+                                Not Agreed
+                              </span>
+                            </>
+                          )}
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -576,17 +1003,46 @@ function ViewMentorDetails() {
 
       {/* Re-approval Modal */}
       {isModalOpen && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-          <div className="bg-gray-800/90 backdrop-blur-md p-6 rounded-2xl w-full max-w-md">
-            <h2 className="text-xl sm:text-2xl font-bold text-white mb-4">
-              Request Re-approval
-            </h2>
+        <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50">
+          <div className="bg-gray-800/90 backdrop-blur-md p-6 rounded-2xl w-full max-w-md border border-gray-700/50">
+            <div className="flex items-center mb-4">
+              <div className="w-1.5 h-6 bg-yellow-500 rounded-full mr-3"></div>
+              <h2 className="text-xl font-bold text-white">
+                Request Re-approval
+              </h2>
+            </div>
             <p className="text-gray-300 mb-4">
               Specify the changes {mentor.fullName} needs to make for
               re-approval.
             </p>
+            <div className="mb-4 max-h-64 overflow-y-auto">
+              <label className="block text-gray-300 mb-2">
+                Select fields to be changed:
+              </label>
+              <div className="space-y-2">
+                {availableFields.map((field) => (
+                  <label key={field} className="flex items-center">
+                    <input
+                      type="checkbox"
+                      value={field}
+                      checked={fieldsToChange.includes(field)}
+                      onChange={(e) => {
+                        const value = e.target.value;
+                        setFieldsToChange((prev) =>
+                          prev.includes(value)
+                            ? prev.filter((item) => item !== value)
+                            : [...prev, value]
+                        );
+                      }}
+                      className="mr-2 h-4 w-4 text-yellow-400 bg-gray-700 border-gray-600 rounded focus:ring-yellow-400"
+                    />
+                    <span className="text-white">{field}</span>
+                  </label>
+                ))}
+              </div>
+            </div>
             <textarea
-              className="w-full h-32 p-3 bg-gray-700/50 text-white rounded-lg border border-gray-600 focus:outline-none focus:border-yellow-400"
+              className="w-full h-32 p-3 bg-gray-700/50 text-white rounded-lg border border-gray-600 focus:outline-none focus:border-yellow-400 resize-none"
               placeholder="Enter changes needed..."
               value={changesNeeded}
               onChange={(e) => setChangesNeeded(e.target.value)}
@@ -594,13 +1050,13 @@ function ViewMentorDetails() {
             <div className="flex justify-end gap-4 mt-6">
               <button
                 onClick={() => setIsModalOpen(false)}
-                className="bg-gray-600 hover:bg-gray-700 text-white px-4 py-2 rounded text-sm font-medium transition-colors duration-200"
+                className="bg-gray-600 hover:bg-gray-700 text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-200"
               >
                 Cancel
               </button>
               <button
                 onClick={handleRequestReapproval}
-                className="bg-yellow-600 hover:bg-yellow-700 text-white px-4 py-2 rounded text-sm font-medium transition-colors duration-200"
+                className="bg-yellow-600 hover:bg-yellow-700 text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-200"
               >
                 Send Request
               </button>

--- a/src/components/ReApproveMentor.jsx
+++ b/src/components/ReApproveMentor.jsx
@@ -1,0 +1,57 @@
+// import React from "react";
+// import { Link } from "react-router-dom";
+// import { useContext } from "react";
+// import { LoginContext } from "../Context/LoginContext";
+// import { auth } from "../BACKEND/firebase.js";
+// import { signOut } from "firebase/auth";
+
+// const ReApproveMentor = () => {
+//   const { userType, reapprovalStatus, reapprovalFields, reapprovalReason } =
+//     useContext(LoginContext);
+//   if (
+//     userType === "pendingMentor" &&
+//     reapprovalStatus === "reapproval_pending"
+//   ) {
+//     return (
+//       <div className="min-h-screen flex items-center justify-center bg-gray-900 px-4">
+//         <div className="bg-gray-800 p-6 rounded-2xl shadow-lg max-w-md text-center">
+//           <h2 className="text-2xl font-semibold text-yellow-400 mb-4">
+//             Re-approval Required 📝
+//           </h2>
+//           <p className="text-gray-300 text-base mb-2">
+//             The MentorConnect Team has requested changes to your profile.
+//           </p>
+//           <p className="text-gray-300 text-base mb-4">
+//             <strong>Status:</strong> Re-approval Pending
+//           </p>
+//           <ul className="text-left text-gray-300 list-disc list-inside mb-4">
+//             {reapprovalFields.map((field) => (
+//               <li key={field} className="capitalize">
+//                 {field.replace(/([A-Z])/g, " $1").trim()}
+//               </li>
+//             ))}
+//           </ul>
+//           {reapprovalReason && (
+//             <p className="text-gray-300 text-base mb-4">
+//               <strong>Reason:</strong> {reapprovalReason}
+//             </p>
+//           )}
+//           <Link
+//             href={`/mentorProfileCreate/${auth.currentUser?.uid}`}
+//             className="inline-block bg-yellow-400 text-gray-900 px-6 py-2 rounded-lg font-semibold hover:bg-yellow-500 transition duration-300"
+//           >
+//             Re-approve Profile
+//           </Link>
+//           <button
+//             onClick={() => signOut(auth)}
+//             className="mt-4 bg-gray-600 text-white px-6 py-2 rounded-lg font-semibold hover:bg-gray-700 transition duration-300"
+//           >
+//             Sign Out
+//           </button>
+//         </div>
+//       </div>
+//     );
+//   }
+// };
+
+// export default ReApproveMentor;

--- a/src/components/layout/Navbar.jsx
+++ b/src/components/layout/Navbar.jsx
@@ -19,13 +19,16 @@ const Navbar = () => {
     setLoginState,
     setUserProfilePhoto,
     setIsApproved,
+    reapprovalStatus,
+    reapprovalFields,
+    reapprovalReason,
   } = useContext(LoginContext);
 
   const navigate = useNavigate();
 
   const handleLogout = async () => {
     try {
-      await signOut(auth); // Firebase se sign out
+      await signOut(auth);
       localStorage.clear();
       setLoginState(false);
       setUserEmail(null);
@@ -76,22 +79,23 @@ const Navbar = () => {
           >
             About
           </Link>
-          {/* <Link
-            to="/mentorProfileCreate"
-            className="block py-2 px-4 sm:px-6 text-base sm:text-lg hover:text-yellow-300 transition duration-300"
-          >
-            Mentor Profile Creation
-          </Link> */}
-
-          {userType === "admin" && (
-            <>
+          {userType === "pendingMentor" &&
+            reapprovalStatus === "reapproval_pending" && (
               <Link
-                to="/adminDashboard"
+                to={`/mentorProfileCreate/${auth.currentUser?.uid}`}
                 className="block py-2 px-4 sm:px-6 text-base sm:text-lg hover:text-yellow-300 transition duration-300"
               >
-                Admin DashBoard
+                Re-approve Profile
               </Link>
-            </>
+            )}
+
+          {userType === "admin" && (
+            <Link
+              to="/adminDashBoard"
+              className="block py-2 px-4 sm:px-6 text-base sm:text-lg hover:text-yellow-300 transition duration-300"
+            >
+              Admin DashBoard
+            </Link>
           )}
 
           {userType === "student" && (
@@ -122,17 +126,32 @@ const Navbar = () => {
 
           {userEmail && userType !== "pendingMentor" ? (
             <div className="relative">
-              <div className="flex flex-col items-center space-y-1 sm:px-6">
+              <div className="flex flex-col items-center space-y-1 sm:px-6 relative">
                 <button
                   onClick={() => setShowMenu(!showMenu)}
-                  className="text-base sm:text-lg hover:text-yellow-300 transition duration-300"
+                  className="text-base sm:text-lg hover:text-yellow-300 transition duration-300 relative"
                 >
                   <i className="hover:text-gray-900/90 hover:bg-yellow-300 p-[10px] rounded-full fa-solid fa-user text-white"></i>
+                  {reapprovalStatus === "reapproval_pending" && (
+                    <span className="absolute top-0 right-0 bg-red-500 text-white text-xs rounded-full h-4 w-4 flex items-center justify-center"></span>
+                  )}
                 </button>
                 <p className="text-white text-sm sm:text-base">{userName}</p>
               </div>
               {showMenu && (
-                <div className="absolute right-0 mt-2 w-30 bg-gray-800 rounded-md shadow-lg z-20">
+                <div className="absolute right-0 mt-2 w-48 bg-gray-800 rounded-md shadow-lg z-20">
+                  {reapprovalStatus === "reapproval_pending" && (
+                    <div className="px-4 py-2 text-sm text-white bg-gray-700">
+                      <p className="font-semibold">
+                        Notification from MentorConnect
+                      </p>
+                      <p className="mt-1">Status: Re-approval Pending</p>
+                      <p className="mt-1">
+                        Fields: {reapprovalFields.join(", ")}
+                      </p>
+                      <p className="mt-1">Reason: {reapprovalReason}</p>
+                    </div>
+                  )}
                   <Link
                     to={
                       userType === "mentor"
@@ -170,6 +189,56 @@ const Navbar = () => {
                 </Link>
               </>
             )
+          )}
+
+          {userEmail && userType === "pendingMentor" && (
+            <div className="relative">
+              <div className="flex flex-col items-center space-y-1 sm:px-6 relative">
+                <button
+                  onClick={() => setShowMenu(!showMenu)}
+                  className="text-base sm:text-lg hover:text-yellow-300 transition duration-300 relative"
+                >
+                  <i className="fa-solid fa-bell text-red-500 text-xl"></i>
+                  {reapprovalStatus === "reapproval_pending" && (
+                    <span className="absolute top-0 right-0 bg-red-500 text-white text-xs rounded-full h-4 w-4 flex items-center justify-center"></span>
+                  )}
+                </button>
+                <p className="text-white text-sm sm:text-base">{userName}</p>
+              </div>
+              {showMenu && (
+                <div className="absolute right-0 mt-2 w-56 bg-gray-800 rounded-md shadow-lg z-20">
+                  {reapprovalStatus === "reapproval_pending" && (
+                    <div className="px-4 py-2 text-sm text-white bg-gray-700">
+                      <p className="font-semibold">
+                        Notification from MentorConnect
+                      </p>
+                      <p className="mt-1">Status: Re-approval Pending</p>
+                      <p className="mt-1">
+                        Fields: {reapprovalFields.join(", ")}
+                      </p>
+                      <p className="mt-1">Reason: {reapprovalReason}</p>
+                    </div>
+                  )}
+                  <Link
+                    to={
+                      userType === "mentor"
+                        ? "/mentorProfile"
+                        : "/studentProfile"
+                    }
+                    className="block px-4 py-2 text-sm text-white hover:bg-gray-700"
+                    onClick={() => setShowMenu(false)}
+                  >
+                    View Profile
+                  </Link>
+                  <button
+                    onClick={handleLogout}
+                    className="block w-full text-left px-4 py-2 text-sm text-white hover:bg-gray-700"
+                  >
+                    Logout
+                  </button>
+                </div>
+              )}
+            </div>
           )}
         </nav>
       </div>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -16,7 +16,9 @@ import RequirementDetail from "./pages/RequirementDetail";
 import AdminDashboard from "../src/admin/AdminDashboard";
 import ViewMentorDetails from "./admin/ViewMentorDetails";
 import About from "./pages/About";
+// import ReApproveMentor from "./components/ReApproveMentor";
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
+
 const router = createBrowserRouter([
   {
     path: "/",
@@ -43,7 +45,7 @@ const router = createBrowserRouter([
     element: <Signup />,
   },
   {
-    path: "/mentorProfileCreate",
+    path: "/mentorProfileCreate/:id", // Fixed route syntax
     element: <MentorProfileCreation />,
   },
   {
@@ -71,13 +73,17 @@ const router = createBrowserRouter([
     element: <RequirementDetail />,
   },
   {
-    path: "adminDashBoard",
+    path: "/adminDashBoard", // Fixed typo in path
     element: <AdminDashboard />,
   },
   {
     path: "/viewMentorDetails/:id",
     element: <ViewMentorDetails />,
   },
+  // {
+  //   path: "/reApproveMentor",
+  //   element: <ReApproveMentor />,
+  // },
 ]);
 
 createRoot(document.getElementById("root")).render(

--- a/src/pages/MentorProfileCreation.jsx
+++ b/src/pages/MentorProfileCreation.jsx
@@ -1,8 +1,9 @@
 import React, { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import { useContext } from "react";
 import { LoginContext } from "../Context/LoginContext.jsx";
-import { doc, setDoc, updateDoc } from "firebase/firestore";
+import { doc, setDoc, updateDoc, getDoc } from "firebase/firestore";
 import { db, auth } from "../BACKEND/firebase.js";
 import { signOut } from "firebase/auth";
 import Navbar from "../components/layout/Navbar";
@@ -22,7 +23,10 @@ const apiKey = "5eba8f49c8a995e0e09ddd9c";
 function MentorProfileCreation() {
   const navigate = useNavigate();
   const [currentStep, setCurrentStep] = useState(1);
-  const { userName, UserProfilePhoto } = useContext(LoginContext);
+  const { userName, UserProfilePhoto, reapprovalStatus, reapprovalFields } =
+    useContext(LoginContext);
+  const { id } = useParams();
+  const isReapproval = reapprovalStatus === "reapproval_pending";
 
   const [mentorApprovalData, setMentorApprovalData] = useState({
     fullName: userName || "",
@@ -36,6 +40,7 @@ function MentorProfileCreation() {
     highestQualification: "",
     certifications: [],
     resume: "",
+    status: isReapproval ? "reapproval_pending" : "pending_approval",
     timeSlots: [],
     preferredDays: [],
     timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
@@ -59,6 +64,7 @@ function MentorProfileCreation() {
   const [newCertification, setNewCertification] = useState("");
   const [newLanguage, setNewLanguage] = useState("");
   const [error, setError] = useState("");
+  const [loading, setLoading] = useState(true);
 
   const categories = [
     "Web Development",
@@ -138,14 +144,44 @@ function MentorProfileCreation() {
     endTime: "10:00",
   });
 
-  const steps = [
-    { number: 1, title: "Basic Info" },
-    { number: 2, title: "Expertise & Education" },
-    { number: 3, title: "Availability & Pricing" },
-    { number: 4, title: "Social & Demo" },
-    { number: 5, title: "Terms" },
-    { number: 6, title: "Preview" },
-  ];
+  const steps = isReapproval
+    ? [{ number: 1, title: "Re-approve Profile" }]
+    : [
+        { number: 1, title: "Basic Info" },
+        { number: 2, title: "Expertise & Education" },
+        { number: 3, title: "Availability & Pricing" },
+        { number: 4, title: "Social & Demo" },
+        { number: 5, title: "Terms" },
+        { number: 6, title: "Preview" },
+      ];
+
+  useEffect(() => {
+    const fetchMentorData = async () => {
+      try {
+        if (!auth.currentUser || auth.currentUser.uid !== id) {
+          throw new Error("Unauthorized access");
+        }
+
+        const mentorRequestRef = doc(db, "mentorRequest", id);
+        const mentorRequestSnap = await getDoc(mentorRequestRef);
+        if (mentorRequestSnap.exists()) {
+          const data = mentorRequestSnap.data();
+          setMentorApprovalData((prev) => ({
+            ...prev,
+            ...data,
+            status: isReapproval
+              ? "reapproval_pending"
+              : data.status || "pending_approval",
+          }));
+        }
+        setLoading(false);
+      } catch (err) {
+        setError(err.message);
+        setLoading(false);
+      }
+    };
+    fetchMentorData();
+  }, [id, isReapproval]);
 
   useEffect(() => {
     fetch(`https://v6.exchangerate-api.com/v6/${apiKey}/latest/USD`)
@@ -294,6 +330,14 @@ function MentorProfileCreation() {
   };
 
   const validateStep = (step) => {
+    if (isReapproval) {
+      return reapprovalFields.every((field) => {
+        if (Array.isArray(mentorApprovalData[field])) {
+          return mentorApprovalData[field].length > 0;
+        }
+        return mentorApprovalData[field] && mentorApprovalData[field].trim();
+      });
+    }
     switch (step) {
       case 1:
         return (
@@ -335,7 +379,7 @@ function MentorProfileCreation() {
     }
   };
 
-  function mentorApprovalRequest(e) {
+  const mentorApprovalRequest = async (e) => {
     e.preventDefault();
     const user = auth.currentUser;
     const uid = user?.uid;
@@ -348,32 +392,48 @@ function MentorProfileCreation() {
     const mentorRequestRef = doc(db, "mentorRequest", uid);
     const userRef = doc(db, "users", uid);
 
-    setDoc(
-      mentorRequestRef,
-      {
-        uid: uid,
-        ...mentorApprovalData,
-        isApproved: false,
-        submittedAt: new Date().toISOString(),
-      },
-      { merge: true }
-    )
-      .then(() => {
-        return updateDoc(userRef, {
+    try {
+      if (isReapproval) {
+        const updateData = {
+          status: "pending_approval",
+          updatedAt: new Date().toISOString(),
+          updatedBy: uid,
+          reapproval_reason: "",
+          reapproval_fields: [],
+        };
+        reapprovalFields.forEach((field) => {
+          if (
+            mentorApprovalData[field] !== getDoc(mentorRequestRef).data()[field]
+          ) {
+            updateData[field] = mentorApprovalData[field];
+          }
+        });
+        await updateDoc(mentorRequestRef, updateData);
+        alert("Profile updated successfully! Awaiting admin approval.");
+        navigate("/profile");
+      } else {
+        await setDoc(
+          mentorRequestRef,
+          {
+            uid: uid,
+            ...mentorApprovalData,
+            isApproved: false,
+            submittedAt: new Date().toISOString(),
+          },
+          { merge: true }
+        );
+        await updateDoc(userRef, {
           userType: "pendingMentor",
         });
-      })
-      .then(() => {
-        signOut(auth).then(() => {
-          alert("Profile submitted! You'll be notified after approval.");
-          navigate("/login");
-        });
-      })
-      .catch((error) => {
-        console.error("Error submitting mentor request: ", error);
-        setError("Something went wrong. Please try again.");
-      });
-  }
+        await signOut(auth);
+        alert("Profile submitted! You'll be notified after approval.");
+        navigate("/login");
+      }
+    } catch (error) {
+      console.error("Error submitting mentor request: ", error);
+      setError("Something went wrong. Please try again.");
+    }
+  };
 
   const nextStep = () => {
     if (validateStep(currentStep)) {
@@ -386,44 +446,84 @@ function MentorProfileCreation() {
 
   const prevStep = () => setCurrentStep(currentStep - 1);
 
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-gray-900 text-white flex justify-center items-center">
+        <svg
+          className="animate-spin h-8 w-8 text-yellow-400"
+          viewBox="0 0 24 24"
+        >
+          <circle
+            cx="12"
+            cy="12"
+            r="10"
+            stroke="currentColor"
+            strokeWidth="4"
+            fill="none"
+          />
+          <path fill="currentColor" d="M4 12a8 8 0 018-8v8h-8z" />
+        </svg>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="min-h-screen bg-gray-900 text-white flex items-center justify-center">
+        <h1>Error: {error}</h1>
+      </div>
+    );
+  }
+
   return (
     <div className="min-h-screen bg-gray-900 text-gray-200 font-sans">
       <Navbar />
       <section className="bg-gradient-to-br from-gray-800 via-gray-900 to-blue-900 pt-22 pb-12 min-h-screen flex items-center">
-        <div className="container  lg:mt-10 mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="container lg:mt-10 mx-auto px-4 sm:px-6 lg:px-8">
           <div className="max-w-5xl mx-auto bg-gray-800 rounded-xl shadow-2xl overflow-hidden">
             <div className="bg-gray-700 px-6 py-6 border-b border-gray-600">
               <h2 className="text-2xl sm:text-3xl font-bold text-white">
-                Mentor Profile Creation
+                {isReapproval
+                  ? "Re-approve Your Profile"
+                  : "Mentor Profile Creation"}
               </h2>
               <p className="text-gray-400 mt-1 text-sm sm:text-base">
-                Complete all steps to create your professional mentor profile
+                {isReapproval
+                  ? "Update the requested fields to re-approve your profile"
+                  : "Complete all steps to create your professional mentor profile"}
               </p>
-              <div className="w-full bg-gray-600 rounded-full h-2.5 mt-4">
-                <div
-                  className="bg-yellow-400 h-2.5 rounded-full transition-all duration-300"
-                  style={{ width: `${(currentStep / steps.length) * 100}%` }}
-                ></div>
-              </div>
-              <div className="relative mt-6 flex flex-wrap gap-2 pb-2">
-                {steps.map((step) => (
-                  <button
-                    key={step.number}
-                    onClick={() =>
-                      currentStep >= step.number && setCurrentStep(step.number)
-                    }
-                    className={`relative text-xs sm:text-sm font-semibold whitespace-nowrap px-4 py-2 rounded-lg transition-colors duration-200 ${
-                      currentStep === step.number
-                        ? "bg-gray-800 text-yellow-400"
-                        : currentStep > step.number
-                        ? "bg-gray-600 text-gray-200 hover:bg-gray-500"
-                        : "bg-gray-700 text-gray-400 cursor-not-allowed"
-                    }`}
-                  >
-                    {step.title}
-                  </button>
-                ))}
-              </div>
+              {!isReapproval && (
+                <>
+                  <div className="w-full bg-gray-600 rounded-full h-2.5 mt-4">
+                    <div
+                      className="bg-yellow-400 h-2.5 rounded-full transition-all duration-300"
+                      style={{
+                        width: `${(currentStep / steps.length) * 100}%`,
+                      }}
+                    ></div>
+                  </div>
+                  <div className="relative mt-6 flex flex-wrap gap-2 pb-2">
+                    {steps.map((step) => (
+                      <button
+                        key={step.number}
+                        onClick={() =>
+                          currentStep >= step.number &&
+                          setCurrentStep(step.number)
+                        }
+                        className={`relative text-xs sm:text-sm font-semibold whitespace-nowrap px-4 py-2 rounded-lg transition-colors duration-200 ${
+                          currentStep === step.number
+                            ? "bg-gray-800 text-yellow-400"
+                            : currentStep > step.number
+                            ? "bg-gray-600 text-gray-200 hover:bg-gray-500"
+                            : "bg-gray-700 text-gray-400 cursor-not-allowed"
+                        }`}
+                      >
+                        {step.title}
+                      </button>
+                    ))}
+                  </div>
+                </>
+              )}
             </div>
             <form onSubmit={mentorApprovalRequest}>
               <div className="p-6">
@@ -433,26 +533,74 @@ function MentorProfileCreation() {
                   </div>
                 )}
                 <div className="animate-fade-in">
-                  {currentStep === 1 && (
-                    <Step1BasicInfo
-                      data={mentorApprovalData}
-                      setData={setMentorApprovalData}
-                      handleFileUpload={handleFileUpload}
-                    />
-                  )}
-                  {currentStep === 2 && (
-                    <>
-                      <Step2ExpertiseSkills
-                        data={mentorApprovalData}
-                        setData={setMentorApprovalData}
-                        newSkill={newSkill}
-                        setNewSkill={setNewSkill}
-                        addSkill={addSkill}
-                        removeSkill={removeSkill}
-                        categories={categories}
-                        experienceLevels={experienceLevels}
-                      />
-                      <div className="mt-6">
+                  {isReapproval ? (
+                    <div className="space-y-6">
+                      {reapprovalFields.includes("fullName") && (
+                        <Step1BasicInfo
+                          data={mentorApprovalData}
+                          setData={setMentorApprovalData}
+                          handleFileUpload={handleFileUpload}
+                          fields={["fullName"]}
+                        />
+                      )}
+                      {reapprovalFields.includes("professionalTitle") && (
+                        <Step1BasicInfo
+                          data={mentorApprovalData}
+                          setData={setMentorApprovalData}
+                          handleFileUpload={handleFileUpload}
+                          fields={["professionalTitle"]}
+                        />
+                      )}
+                      {reapprovalFields.includes("bio") && (
+                        <Step1BasicInfo
+                          data={mentorApprovalData}
+                          setData={setMentorApprovalData}
+                          handleFileUpload={handleFileUpload}
+                          fields={["bio"]}
+                        />
+                      )}
+                      {reapprovalFields.includes("profilePicture") && (
+                        <Step1BasicInfo
+                          data={mentorApprovalData}
+                          setData={setMentorApprovalData}
+                          handleFileUpload={handleFileUpload}
+                          fields={["profilePicture"]}
+                        />
+                      )}
+                      {reapprovalFields.some((field) =>
+                        [
+                          "skills",
+                          "primaryCategory",
+                          "experienceLevel",
+                          "yearsOfExperience",
+                        ].includes(field)
+                      ) && (
+                        <Step2ExpertiseSkills
+                          data={mentorApprovalData}
+                          setData={setMentorApprovalData}
+                          newSkill={newSkill}
+                          setNewSkill={setNewSkill}
+                          addSkill={addSkill}
+                          removeSkill={removeSkill}
+                          categories={categories}
+                          experienceLevels={experienceLevels}
+                          fields={reapprovalFields.filter((field) =>
+                            [
+                              "skills",
+                              "primaryCategory",
+                              "experienceLevel",
+                              "yearsOfExperience",
+                            ].includes(field)
+                          )}
+                        />
+                      )}
+                      {reapprovalFields.some((field) =>
+                        [
+                          "highestQualification",
+                          "certifications",
+                          "resume",
+                        ].includes(field)
+                      ) && (
                         <Step3EducationCertifications
                           data={mentorApprovalData}
                           setData={setMentorApprovalData}
@@ -461,69 +609,211 @@ function MentorProfileCreation() {
                           addCertification={addCertification}
                           removeCertification={removeCertification}
                           handleFileUpload={handleFileUpload}
+                          fields={reapprovalFields.filter((field) =>
+                            [
+                              "highestQualification",
+                              "certifications",
+                              "resume",
+                            ].includes(field)
+                          )}
                         />
-                      </div>
-                    </>
-                  )}
-                  {currentStep === 3 && (
-                    <>
-                      <Step4Availability
-                        data={mentorApprovalData}
-                        setData={setMentorApprovalData}
-                        newSlot={newSlot}
-                        setNewSlot={setNewSlot}
-                        addTimeSlot={addTimeSlot}
-                        removeTimeSlot={removeTimeSlot}
-                        days={days}
-                        timeZones={timeZones}
-                      />
-                      <div className="mt-6">
-                        <Step5Pricing
+                      )}
+                      {reapprovalFields.some((field) =>
+                        [
+                          "timeSlots",
+                          "preferredDays",
+                          "timeZone",
+                          "sessionPrice",
+                          "currency",
+                          "sessionDuration",
+                        ].includes(field)
+                      ) && (
+                        <>
+                          <Step4Availability
+                            data={mentorApprovalData}
+                            setData={setMentorApprovalData}
+                            newSlot={newSlot}
+                            setNewSlot={setNewSlot}
+                            addTimeSlot={addTimeSlot}
+                            removeTimeSlot={removeTimeSlot}
+                            days={days}
+                            timeZones={timeZones}
+                            fields={reapprovalFields.filter((field) =>
+                              [
+                                "timeSlots",
+                                "preferredDays",
+                                "timeZone",
+                              ].includes(field)
+                            )}
+                          />
+                          <Step5Pricing
+                            data={mentorApprovalData}
+                            setData={setMentorApprovalData}
+                            currencies={currencies}
+                            currencySymbols={currencySymbols}
+                            sessionDurations={sessionDurations}
+                            fields={reapprovalFields.filter((field) =>
+                              [
+                                "sessionPrice",
+                                "currency",
+                                "sessionDuration",
+                              ].includes(field)
+                            )}
+                          />
+                        </>
+                      )}
+                      {reapprovalFields.some((field) =>
+                        [
+                          "linkedin",
+                          "github",
+                          "portfolio",
+                          "youtube",
+                          "demoVideo",
+                          "experience",
+                          "teachingStyle",
+                          "languages",
+                        ].includes(field)
+                      ) && (
+                        <>
+                          <Step6SocialPortfolio
+                            data={mentorApprovalData}
+                            setData={setMentorApprovalData}
+                            fields={reapprovalFields.filter((field) =>
+                              [
+                                "linkedin",
+                                "github",
+                                "portfolio",
+                                "youtube",
+                              ].includes(field)
+                            )}
+                          />
+                          <Step7DemoVideo
+                            data={mentorApprovalData}
+                            setData={setMentorApprovalData}
+                            newLanguage={newLanguage}
+                            setNewLanguage={setNewLanguage}
+                            addLanguage={addLanguage}
+                            removeLanguage={removeLanguage}
+                            handleFileUpload={handleFileUpload}
+                            teachingStyles={teachingStyles}
+                            languagesList={languagesList}
+                            fields={reapprovalFields.filter((field) =>
+                              [
+                                "demoVideo",
+                                "experience",
+                                "teachingStyle",
+                                "languages",
+                              ].includes(field)
+                            )}
+                          />
+                        </>
+                      )}
+                      {reapprovalFields.includes("agreedToTerms") ||
+                      reapprovalFields.includes("agreedToNDA") ? (
+                        <Step8Terms
                           data={mentorApprovalData}
                           setData={setMentorApprovalData}
-                          currencies={currencies}
-                          currencySymbols={currencySymbols}
-                          sessionDurations={sessionDurations}
+                          fields={reapprovalFields.filter((field) =>
+                            ["agreedToTerms", "agreedToNDA"].includes(field)
+                          )}
                         />
-                      </div>
-                    </>
-                  )}
-                  {currentStep === 4 && (
+                      ) : null}
+                    </div>
+                  ) : (
                     <>
-                      <Step6SocialPortfolio
-                        data={mentorApprovalData}
-                        setData={setMentorApprovalData}
-                      />
-                      <div className="mt-6">
-                        <Step7DemoVideo
+                      {currentStep === 1 && (
+                        <Step1BasicInfo
                           data={mentorApprovalData}
                           setData={setMentorApprovalData}
-                          newLanguage={newLanguage}
-                          setNewLanguage={setNewLanguage}
-                          addLanguage={addLanguage}
-                          removeLanguage={removeLanguage}
                           handleFileUpload={handleFileUpload}
-                          teachingStyles={teachingStyles}
-                          languagesList={languagesList}
                         />
-                      </div>
+                      )}
+                      {currentStep === 2 && (
+                        <>
+                          <Step2ExpertiseSkills
+                            data={mentorApprovalData}
+                            setData={setMentorApprovalData}
+                            newSkill={newSkill}
+                            setNewSkill={setNewSkill}
+                            addSkill={addSkill}
+                            removeSkill={removeSkill}
+                            categories={categories}
+                            experienceLevels={experienceLevels}
+                          />
+                          <div className="mt-6">
+                            <Step3EducationCertifications
+                              data={mentorApprovalData}
+                              setData={setMentorApprovalData}
+                              newCertification={newCertification}
+                              setNewCertification={setNewCertification}
+                              addCertification={addCertification}
+                              removeCertification={removeCertification}
+                              handleFileUpload={handleFileUpload}
+                            />
+                          </div>
+                        </>
+                      )}
+                      {currentStep === 3 && (
+                        <>
+                          <Step4Availability
+                            data={mentorApprovalData}
+                            setData={setMentorApprovalData}
+                            newSlot={newSlot}
+                            setNewSlot={setNewSlot}
+                            addTimeSlot={addTimeSlot}
+                            removeTimeSlot={removeTimeSlot}
+                            days={days}
+                            timeZones={timeZones}
+                          />
+                          <div className="mt-6">
+                            <Step5Pricing
+                              data={mentorApprovalData}
+                              setData={setMentorApprovalData}
+                              currencies={currencies}
+                              currencySymbols={currencySymbols}
+                              sessionDurations={sessionDurations}
+                            />
+                          </div>
+                        </>
+                      )}
+                      {currentStep === 4 && (
+                        <>
+                          <Step6SocialPortfolio
+                            data={mentorApprovalData}
+                            setData={setMentorApprovalData}
+                          />
+                          <div className="mt-6">
+                            <Step7DemoVideo
+                              data={mentorApprovalData}
+                              setData={setMentorApprovalData}
+                              newLanguage={newLanguage}
+                              setNewLanguage={setNewLanguage}
+                              addLanguage={addLanguage}
+                              removeLanguage={removeLanguage}
+                              handleFileUpload={handleFileUpload}
+                              teachingStyles={teachingStyles}
+                              languagesList={languagesList}
+                            />
+                          </div>
+                        </>
+                      )}
+                      {currentStep === 5 && (
+                        <Step8Terms
+                          data={mentorApprovalData}
+                          setData={setMentorApprovalData}
+                        />
+                      )}
+                      {currentStep === 6 && (
+                        <Step9Preview
+                          data={mentorApprovalData}
+                          currencySymbols={currencySymbols}
+                        />
+                      )}
                     </>
-                  )}
-                  {currentStep === 5 && (
-                    <Step8Terms
-                      data={mentorApprovalData}
-                      setData={setMentorApprovalData}
-                    />
-                  )}
-                  {currentStep === 6 && (
-                    <Step9Preview
-                      data={mentorApprovalData}
-                      currencySymbols={currencySymbols}
-                    />
                   )}
                 </div>
                 <div className="flex justify-between pt-6">
-                  {currentStep > 1 && (
+                  {!isReapproval && currentStep > 1 && (
                     <button
                       type="button"
                       onClick={prevStep}
@@ -532,7 +822,7 @@ function MentorProfileCreation() {
                       Back
                     </button>
                   )}
-                  {currentStep < 6 && (
+                  {!isReapproval && currentStep < 6 && (
                     <button
                       type="button"
                       onClick={nextStep}
@@ -541,12 +831,12 @@ function MentorProfileCreation() {
                       Next: {steps[currentStep].title}
                     </button>
                   )}
-                  {currentStep === 6 && (
+                  {(isReapproval || currentStep === 6) && (
                     <button
                       type="submit"
                       className="px-6 py-2 bg-yellow-400 hover:bg-yellow-500 text-gray-900 font-medium rounded-lg transition-colors duration-200 shadow-md"
                     >
-                      Submit Profile
+                      {isReapproval ? "Submit Updates" : "Submit Profile"}
                     </button>
                   )}
                 </div>


### PR DESCRIPTION


- Admin can now send re-approval email to mentors who require profile updates
- On login, if mentor status is 'reapproval_pending', a dedicated UI is shown with: • Required fields to be updated • Re-approval reason from admin • Buttons: 'Sign Out' and 'Re-approve Profile'
- Clicking 'Re-approve Profile' should redirect to MentorProfileCreate page
- After resubmission, updated data is saved to the mentors collection

⚠️ Known Issue:
- 'Re-approve Profile' button is not navigating to MentorProfileCreate (MPC) page as expected. Needs fix.